### PR TITLE
PdWebParty Work

### DIFF
--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -19,10 +19,10 @@ INSTALL_PATH = $(EM_PATH)/projects/pd-l2ork-web
 DESTDIR = $(BUILD_PATH)/pd-l2ork-web/
 objectsdir = extra/
 WARN_FLAGS = -Wall -W -Wno-unused-parameter
-EM_FLAGS = -s SIDE_MODULE=1 -O3 -fsanitize=address
+EM_FLAGS = -s SIDE_MODULE=1 -O3
 TYPE = Release
 ifeq ($(DEBUG), true)
-    EM_FLAGS = -s SIDE_MODULE=1 -g -fsanitize=address
+    EM_FLAGS = -s SIDE_MODULE=1 -g
     TYPE = Debug
 endif
 CFLAGS = -DPD -I$(PD_PATH)/src $(WARN_FLAGS) $(EM_FLAGS)

--- a/emscripten/projects/PdWebParty/public/js/main.js
+++ b/emscripten/projects/PdWebParty/public/js/main.js
@@ -3374,6 +3374,7 @@ async function openPatch(content, filename) {
                 }
                 layers.push({
                     arrays: [],
+                    messages: [],
                     guiObjects: [],
                     labels: [],
                     nextGUIID: -1,
@@ -3435,6 +3436,11 @@ async function openPatch(content, filename) {
                     layer.dimensions.inlineY = +args[3];
                     layer.name = [...args,...(layer.argsInherited ? [] : layer.args)].slice(4).join(' ');
                     if(layer.showContents) {
+                        for(let message of layer.messages) {
+                            for(let text of message.svgText)
+                                configure_item(text, {display: "none"});
+                            configure_item(message.border, {display: "none"});
+                        }
                         configure_item(layer.canvas, {
                             viewBox: `${layer.dimensions.contentX} ${layer.dimensions.contentY} ${layer.dimensions.coords.w} ${layer.dimensions.coords.h}`,
                             width: layer.dimensions.coords.w,
@@ -4528,7 +4534,7 @@ async function openPatch(content, filename) {
                 }
                 break;
             case "#X msg":
-                if(args.length > 3 && !layer.showContents) {
+                if(args.length > 3) {
                     const data = {};
                     data.type = args[1];
                     data.x_pos = +args[2];
@@ -4540,6 +4546,7 @@ async function openPatch(content, filename) {
                     data.send = [null];
                     data.clickSend = `msg_${layer.id}_${layer.nextGUIID}`
                     data.canvas = layer.canvas;
+                    layer.messages.push(data);
 
                     let nextObjId = layer.nextGUIID, nextSlot = i, depth = 0;
                     for(;lines[nextSlot].startsWith('#X connect') == false || depth > 0; nextSlot++) {
@@ -4925,7 +4932,7 @@ async function openPatch(content, filename) {
         }
     }
 
-    document.getElementById('loadingstage').innerHTML=`Starting PD Engine`;
+    document.getElementById('loadingstage').innerHTML=`Starting Pd-L2Ork Engine`;
     await new Promise(resolve => setTimeout(resolve, 10));
 
     if (nextLayerID == 0)

--- a/emscripten/projects/PdWebParty/public/js/main.js
+++ b/emscripten/projects/PdWebParty/public/js/main.js
@@ -1,4 +1,5 @@
 const isMobile = (typeof window.orientation !== "undefined") || (navigator.userAgent.indexOf('IEMobile') !== -1);
+const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
 const loading = document.getElementById("loading");
 const filter = document.getElementById("filter");
 let currentFile = "";
@@ -68,6 +69,26 @@ let object_types = [
     '#X symbolatom',
     '#X dropdown'
 ];
+let known_objects = [
+    'adc~',
+    'bng',
+    'tgl',
+    'vsl',
+    'hsl',
+    'vradio',
+    'hradio',
+    'flatgui/knob',
+    'vu',
+    'pddplink',
+    'pddp/pddplink',
+    'nbx',
+    'cnv',
+    'key',
+    'keyup',
+    'keyname',
+    'legacy_mousemotion',
+    'legacy_mouseclick'
+  ]
 //END CONSTANTS
 
 
@@ -1795,12 +1816,25 @@ function gui_text(data) {
     }
 }
 
-function gui_mousepoint(e, canvas) { // transforms the mouse position
-    let point = canvas.createSVGPoint();
-    point.x = e.clientX;
-    point.y = e.clientY;
-    point = point.matrixTransform(canvas.getScreenCTM().inverse());
-    return point;
+function gui_mousepoint(e, canvas, precise) { // transforms the mouse position
+    // If we are on firefox, we have to do shenanigans...
+    // First, getScreenCTM only scales, doesnt offset on firefox, for some ungodly reason.
+    // Next, firefox refuses to give us the x/y coordinates of the top-left of an svg element.
+    // It just returns 0/0 for all svg elements. So, we find the border of the canvas and
+    // use it instead to update the CTM. As long as it works, don't question it.
+    // However, this only works reliable for arrays, as other things don't have borders as the
+    // next element. So, if we don't find a border, we just pretent like this coordinate is correct.
+    // This is fine, though, as arrays are the only things that need absolute mouse positions.
+    // Numboxes / knobs / etc. just use relative from where it started.
+    let CTM = canvas.getScreenCTM();
+    if(isFirefox) {
+        let border = canvas.parentNode.childNodes[[...canvas.parentNode.childNodes].indexOf(canvas)+1];
+        if(border.id?.endsWith('border')) {
+            CTM.e = border.getBoundingClientRect().x;
+            CTM.f = border.getBoundingClientRect().y;
+        }
+    }
+    return (new DOMPointReadOnly(e.clientX, e.clientY)).matrixTransform(CTM.inverse());
 }
 function gui_roundedmousepoint(e, canvas) {
     let point = gui_mousepoint(e, canvas);
@@ -1824,6 +1858,7 @@ function gui_bng_circle(data) {
         r: r,
         fill: "none",
         id: `${data.id}_circle`,
+        "shape-rendering": "auto",
         class: "border unclickable"
     }
 }
@@ -2111,19 +2146,27 @@ function gui_slider_onmousedown(data, e, id) {
     touches[id] = {
         data: data,
         point: p,
+        shift: keyDown['Shift'],
         value: data.value
     };
 }
 
 function gui_slider_onmousemove(e, id) {
     if (id in touches) {
+        const p = gui_mousepoint(e, touches[id].data.canvas);
+        if(keyDown['Shift'] != touches[id].shift) {
+            touches[id].point = p;
+            touches[id].value = touches[id].data.value
+            touches[id].shift = keyDown['Shift'];
+        }
+
         const { data, point, value } = touches[id];
-        const p = gui_mousepoint(e, data.canvas);
+        const factor = keyDown['Shift'] ? .01 : 1;
         if (data.type === "vsl") {
-            data.value = Math.max(Math.min(value + (point.y - p.y) * 100, (data.height - 1) * 100), 0);
+            data.value = Math.max(Math.min(value + factor * (point.y - p.y) * 100, (data.height - 1) * 100), 0);
         }
         else {
-            data.value = Math.max(Math.min(value + (p.x - point.x) * 100, (data.width - 1) * 100), 0);
+            data.value = Math.max(Math.min(value + factor * (p.x - point.x) * 100, (data.width - 1) * 100), 0);
         }
         gui_slider_update_indicator(data);
         gui_slider_bang(data);
@@ -2326,6 +2369,7 @@ function gui_knob_circle(data) {
         stroke: "black",
         fill: "none",
         "stroke-width": data.off_width,
+        "shape-rendering": "auto",
         "d": describeArc(data.x_pos + data.size_x/2, data.y_pos + data.size_y/2, data.size_x/2 - 1, 193, 528)
     };
 }
@@ -2347,6 +2391,7 @@ function gui_knob_extracircle(data) {
         fill: "none",
         stroke: colfromload(data.bg_color),
         "stroke-width": data.on_width,
+        "shape-rendering": "auto",
         "d": describeArc(data.x_pos + data.size_x/2, data.y_pos + data.size_y/2, data.size_x/2 - 1, 193, 193 + gui_knob_vto_gui(data) * (528 - 193)),
     }
 }
@@ -2386,18 +2431,26 @@ function gui_knob_onmousedown(data, e, id) {
     gui_knob_touches[id] = {
         data: data,
         point: p,
+        shift: keyDown['Shift'],
         value: data.value
     };
 }
 
 function gui_knob_onmousemove(e, id) {
     if (id in gui_knob_touches) {
+        let p = gui_mousepoint(e, gui_knob_touches[id].data.canvas);
+        if(keyDown['Shift'] != gui_knob_touches[id].shift) {
+            gui_knob_touches[id].point = p;
+            gui_knob_touches[id].value = gui_knob_touches[id].data.value;
+            gui_knob_touches[id].shift = keyDown['Shift'];
+        }
+
         const { data, point, value } = gui_knob_touches[id];
-        const p = gui_mousepoint(e, data.canvas);
+        const factor = keyDown['Shift'] ? .01 : 1;
         if(data.logarithmic)
-            data.value = Math.pow(10,Math.log10(value) + (point.y - p.y) / data.size_y * Math.log10(data.maximum/data.minimum));
+            data.value = Math.pow(10,Math.log10(value) + factor * (point.y - p.y) / data.size_y * Math.log10(data.maximum/data.minimum));
         else
-            data.value = value + (point.y - p.y) / data.size_y * (data.maximum - data.minimum);
+            data.value = value + factor * (point.y - p.y) / data.size_y * (data.maximum - data.minimum);
         data.value = Math.max(Math.min(data.value,data.maximum),data.minimum);
 
         configure_item(data.extracircle, gui_knob_extracircle(data));
@@ -2702,9 +2755,6 @@ function gui_atom_onmouseup(id) {
         delete gui_atom_touches[id];
 }
 function gui_atom_settext(data, text) {
-
-
-    
     if(data.dirtyValue === undefined && data.type === 'floatatom')
         data.svgText.textContent = (Math.round(+text).toString().length > +data.width) ? (data.value > 0 ? '+' : '-') : text.slice(0, +data.width);
     else
@@ -2962,8 +3012,8 @@ function onKeyDown(e) {
 function onKeyUp(e) {
     if(keyboardFocus.data?.onKeyUp)
         keyboardFocus.data.onKeyUp(keyboardFocus.data, e);
+    keyDown[e.key] = false;
     if(keyboardFocus.exclusive == false) {
-        keyDown[e.key] = false;
         for(let listener of inputListeners)
             if(listener.onKeyUp)
                 listener.onKeyUp(e);
@@ -3217,9 +3267,30 @@ function gui_text_text(data, line_index, fontSize) {
 
 //--------------------- patch handling ----------------------------
 async function openPatch(content, filename) {
-
     console.log(`Loading Patch: ${filename}`);
     document.title=filename;
+
+    document.getElementById('loadingstage').innerHTML=`Fetching Dependancies`;
+    await new Promise(Resolve => setTimeout(Resolve, 10));
+    let abstractions = {};
+    let fetchAbstractions = async(content, path) => {
+        let missingAbstractions = [... new Set(content.split(';\n').filter( line => line.startsWith('#X obj') && !known_objects.includes(line.split(' ')[4]) ).map( line => line.split(' ')[4]))];
+        let abstractionData = await Promise.all(missingAbstractions.map(async(obj) => (await getPatchData(`${((new URLSearchParams(window.location.search)).get('url')||'').split('/').slice(0,-1).join('/')}/${path}${obj}.pd`))));
+        let promises = [];
+        for(let abstraction in missingAbstractions) {
+            if(abstractionData[abstraction].content.startsWith('#') && !abstractions[missingAbstractions[abstraction]]) {
+                abstractions[missingAbstractions[abstraction]] = abstractionData[abstraction].content;
+                promises.push(fetchAbstractions(abstractionData[abstraction].content, missingAbstractions[abstraction].split('/').slice(0,-1).join('/')+'/'));
+            }
+        }
+        await Promise.all(promises);
+    }
+    await fetchAbstractions(content,'/');
+
+    document.getElementById('loadingstage').innerHTML=`Parsing Patch`;
+    await new Promise(Resolve => setTimeout(Resolve, 10));
+
+    let start = Date.now();
 
     document.removeEventListener('keydown', onKeyDown);
     document.removeEventListener('keyup', onKeyUp);
@@ -3245,11 +3316,11 @@ async function openPatch(content, filename) {
     let nextLayerID = 0;      //This is used to assign unique IDs to layers to keep track of their objects
     let nextArgs = [];        //This is used to pass arguments from abstractions which are collapsed by the web parser
     let layers = [ { } ];   //Holds all the layers currently being processed. Used as a stack.
-    let lines = content.split(";\n");
-    for(let i = 0; i < lines.length; i++) {
+
+    let lines = content.split(';\n');
+    for(let i = 0; i < lines.length; i++)
         while(lines[i].endsWith('\\'))
             lines.splice(i,2,`${lines[i].slice(0,-1)};\n${lines[i+1]}`);
-    }
     for (let i = 0; i < lines.length; i++) {
         let layer = layers.at(-1); //Shortcut for the current layer being processed so we aren't always writing layers.at(-1)
 
@@ -3280,7 +3351,8 @@ async function openPatch(content, filename) {
         //This is especially important since we flatten all the canvases for compatibility with the emscriptem pd-l2ork
         if(args.slice(0,2).join(' ') != '#X msg')
             for(let i = 0; i < layer.args?.length; i++)
-                    args = args.map(arg => arg.replace(new RegExp(`(?<!\\\\)\\\\\\$${i+1}`,`g`),layer.args[i]));
+                for(let arg = 0; arg < args.length; arg++)
+                    args[arg] = args[arg].replace(new RegExp(`(?<!\\\\)\\\\\\$${i+1}`,`g`),layer.args[i]);
 
         //If we are looking at something that can be connected with a wire, increment the wire counter
         if(object_types.find(type=>lines[i].startsWith(type)))
@@ -3289,6 +3361,17 @@ async function openPatch(content, filename) {
         //Now we switch based on the type of line (first two arguments)
         switch (args.slice(0,2).join(' ')) {
             case "#N canvas":
+                if(layers.length > 25) {
+                    console.error('Max layer depth exceeded, ignoring further layers');
+                    let depth = 0;
+                    for(;lines[i].startsWith('#X restore') == false || depth > 0; i++) {
+                        if(lines[i].startsWith('#N canvas'))
+                            depth++;
+                        if(lines[i].startsWith('#X restore'))
+                            depth--;
+                    }
+                    break;
+                }
                 layers.push({
                     arrays: [],
                     guiObjects: [],
@@ -3384,15 +3467,16 @@ async function openPatch(content, filename) {
                             layer.canvas.style.overflow = 'visible';
                             if (isMobile) {
                                 layer.border.addEventListener("touchstart", function (e) {
-                                    let p = gui_mousepoint(e, canvas);
-                                    let x = Math.floor(screenToCoord(dimensions.coords.l, dimensions.coords.r, dimensions.coords.w, p.x));
-                                    let y = screenToCoord(dimensions.coords.t, dimensions.coords.b, dimensions.coords.h, p.y);
-                                    let array, min = Infinity;
-                                    for(let a of arrays)
-                                        if(a.nums.length > x && Math.abs(a.nums[x] - y) < min)
-                                            min = Math.abs(a.nums[x] - y), array = a;
-                                    for (const touch of (e || window.event).changedTouches)
+                                    for (const touch of (e || window.event).changedTouches) {
+                                        let p = gui_mousepoint(touch, canvas);
+                                        let x = Math.floor(screenToCoord(dimensions.coords.l, dimensions.coords.r, dimensions.coords.w, p.x));
+                                        let y = screenToCoord(dimensions.coords.t, dimensions.coords.b, dimensions.coords.h, p.y);
+                                        let array, min = Infinity;
+                                        for(let a of arrays)
+                                            if(a.nums.length > x && Math.abs(a.nums[x] - y) < min)
+                                                min = Math.abs(a.nums[x] - y), array = a;
                                         array.onmousedown(array, touch, touch.identifier);
+                                    }
                                 });
                             }
                             else {
@@ -4289,7 +4373,7 @@ async function openPatch(content, filename) {
                             layer.guiObjects[layer.nextGUIID] = data;
                             inputListeners.push({
                                 onMouseMove: e => {
-                                    let p = gui_roundedmousepoint(e, data.canvas);
+                                    let p = gui_roundedmousepoint(e, rootCanvas);
                                     gui_send('Float', data.send, p.x);
                                     gui_send('Float', data.auxSend[0], p.y);
                                 }
@@ -4304,14 +4388,14 @@ async function openPatch(content, filename) {
                             layer.guiObjects[layer.nextGUIID] = data;
                             inputListeners.push({
                                 onMouseDown: e => {
-                                    let p = gui_roundedmousepoint(e, data.canvas);
+                                    let p = gui_roundedmousepoint(e, rootCanvas);
                                     gui_send('Float', data.send, 1);
                                     gui_send('Float', data.auxSend[0], e.which);
                                     gui_send('Float', data.auxSend[1], p.x);
                                     gui_send('Float', data.auxSend[2], p.y);
                                 },
                                 onMouseUp: e => {
-                                    let p = gui_roundedmousepoint(e, data.canvas);
+                                    let p = gui_roundedmousepoint(e, rootCanvas);
                                     gui_send('Float', data.send, 0);
                                     gui_send('Float', data.auxSend[0], e.which);
                                     gui_send('Float', data.auxSend[1], p.x);
@@ -4320,17 +4404,18 @@ async function openPatch(content, filename) {
                             })
                             break;
                         }
-                        default: //If we don't have an explicit handling for the object, it's possible that it is an external patch load
-                            //We want to load patch data from the same folder as our current patch, just with a different filename at the end.
-                            let result = (await Promise.all(searchPaths.map(path => getPatchData(`${((new URLSearchParams(window.location.search)).get('url')||'').split('/').slice(0,-1).join('/')}/${path}${args[4]}.pd`)))).find(result => result.content.charAt(0)=='#');
-                            let path = args[4].split('/').slice(0,-1).join('/')+'/';
-                            if(!searchPaths.includes(path))
-                                searchPaths.push(path);
+                        default: //If we don't have an explicit handling for the object, it's possible that it is an external patch load 
+                        //We want to load patch data from the same folder as our current patch, just with a different filename at the end.
+                            // let result = (await Promise.all(searchPaths.map(path => getPatchData(`${((new URLSearchParams(window.location.search)).get('url')||'').split('/').slice(0,-1).join('/')}/${path}${args[4]}.pd`)))).find(result => result.content.charAt(0)=='#');
+                            // let path = args[4].split('/').slice(0,-1).join('/')+'/';
+                            // if(!searchPaths.includes(path))
+                            //     searchPaths.push(path);
+                            let result = abstractions[args[4]];
                             //If the data starts with a #, it is a patch. Otherwise, either the patch does not exist, or this is a non-gui object, and in either case we can ignore it.
                             if(result) {
                                 //We must add an #X restore at the end to undo the #N canvas at the beginning
                                 nextArgs = args.length > 5 ? args.slice(5) : null;
-                                lines.splice(i,1,...result.content.split(';\n').slice(0,-1),`#X restore ${args[2]} ${args[3]} ${args[4]}`);
+                                lines.splice(i,1,...result.split(';\n').slice(0,-1),`#X restore ${args[2]} ${args[3]} ${args[4]}`);
                                 //Since we removed the line that we just processed, our subpatch starts at line i, so we have to process line i again.
                                 i--;
                                 layer.nextGUIID--;
@@ -4368,7 +4453,7 @@ async function openPatch(content, filename) {
                         id: data.id,
                         stroke: data.outlineColor,
                         "stroke-width": "1",
-                        "shape-rendering": "auto",
+                        "shape-rendering": "crispEdges",
                         fill: 'none'
                     }, data.canvas);
                     if(layer.arrays.length) {
@@ -4404,7 +4489,7 @@ async function openPatch(content, filename) {
                                 lastX = curX;
                                 if(data.displayMode == 0 || data.displayMode == 2)
                                     path += `${curX} ${coordToScreen(c.t,c.b,c.h,data.nums[i])} `;
-                                if(data.displayMode == 1)
+                                if(data.displayMode == 1 && i+1 <= c.r)
                                     path += `M ${curX} ${coordToScreen(c.t,c.b,c.h,data.nums[i])} H ${coordToScreen(c.l,c.r,c.w,i + 1) - 1} V ${coordToScreen(c.t,c.b,c.h,data.nums[i])+1} H ${curX} Z `;
                                 if(data.displayMode == 3 && i+1 <= c.r)
                                     path += `M ${curX} ${coordToScreen(c.t,c.b,c.h,data.nums[i])} H ${coordToScreen(c.l,c.r,c.w,i + 1)} V ${c.h} H ${curX} Z `;
@@ -4450,7 +4535,7 @@ async function openPatch(content, filename) {
                 }
                 break;
             case "#X msg":
-                if(args.length > 3 && layer.id == 0) {
+                if(args.length > 3 && !layer.showContents) {
                     const data = {};
                     data.type = args[1];
                     data.x_pos = +args[2];
@@ -4870,8 +4955,15 @@ async function openPatch(content, filename) {
 
     //Next we load our modified lines into the backend of pd-l2ork
     FS.createDataFile("/", filename, new TextEncoder().encode(lines.join(';\n')), true, true, true);
-    Module.pd.openPatch(filename, "/");
-    pdsend("pd dsp 1");
+    console.log('Parse time: '+(Date.now() - start)+'ms');
+    try {
+        Module.pd.openPatch(filename, "/");
+        pdsend("pd dsp 1");
+    } catch (e) {
+        alert("Failed to start PD engine!");
+        console.error(e.stack);
+        return;
+    }
 }
 
 function uploadPatch(file) {
@@ -4896,10 +4988,8 @@ function uploadPatch(file) {
 
 let cachedData = {};
 async function getPatchData(url) {
-    if(!cachedData[url]) {
-        document.getElementById('loadingstage').innerHTML=`Fetching ${url.slice(0,-3)}`;
+    if(!cachedData[url])
         cachedData[url] = await (await fetch(`/api/patch/?url=${encodeURIComponent(url)}`,{method: 'GET'})).json();
-    }
     return cachedData[url];
 }
 

--- a/emscripten/projects/PdWebParty/public/js/main.js
+++ b/emscripten/projects/PdWebParty/public/js/main.js
@@ -4405,17 +4405,10 @@ async function openPatch(content, filename) {
                             break;
                         }
                         default: //If we don't have an explicit handling for the object, it's possible that it is an external patch load 
-                        //We want to load patch data from the same folder as our current patch, just with a different filename at the end.
-                            // let result = (await Promise.all(searchPaths.map(path => getPatchData(`${((new URLSearchParams(window.location.search)).get('url')||'').split('/').slice(0,-1).join('/')}/${path}${args[4]}.pd`)))).find(result => result.content.charAt(0)=='#');
-                            // let path = args[4].split('/').slice(0,-1).join('/')+'/';
-                            // if(!searchPaths.includes(path))
-                            //     searchPaths.push(path);
-                            let result = abstractions[args[4]];
-                            //If the data starts with a #, it is a patch. Otherwise, either the patch does not exist, or this is a non-gui object, and in either case we can ignore it.
-                            if(result) {
+                            if(args[4] in abstractions) {
                                 //We must add an #X restore at the end to undo the #N canvas at the beginning
                                 nextArgs = args.length > 5 ? args.slice(5) : null;
-                                lines.splice(i,1,...result.split(';\n').slice(0,-1),`#X restore ${args[2]} ${args[3]} ${args[4]}`);
+                                lines.splice(i,1,...abstractions[args[4]].split(';\n').slice(0,-1),`#X restore ${args[2]} ${args[3]} ${args[4]}`);
                                 //Since we removed the line that we just processed, our subpatch starts at line i, so we have to process line i again.
                                 i--;
                                 layer.nextGUIID--;
@@ -4928,7 +4921,6 @@ async function openPatch(content, filename) {
                         } else
                             console.warn('Ignoring unsupported wired connection (Code C');
                     }
-                    console.log(layer.guiObjects[args[2]],layer.guiObjects[args[4]]);
                 }
         }
     }

--- a/emscripten/projects/PdWebParty/views/index.html
+++ b/emscripten/projects/PdWebParty/views/index.html
@@ -19,7 +19,7 @@
 <body>
 	<svg id="canvas" width="100%" height="100%" viewBox="0 0 450 300" preserveAspectRatio="xMidYMin meet"></svg>
 	<div id="loading">
-		<h2>Starting pd-l2ork</h2>
+		<h2>Starting PdWebParty</h2>
 		<br />
 		<p id="loadingstage">Initialization</p>
 		<br />

--- a/externals/Makefile
+++ b/externals/Makefile
@@ -156,7 +156,7 @@ lib_targets = loaders-libdir pddp
 INCREMENTAL = yes
 else ifeq ($(EMSCRIPTEN),yes)
 # original one used by the first iteration of PdWebParty: lib_targets = arraysize autotune bassemu boids bsaylor comport creb cxc earplug ekext ext13 freeverb ggee hcs iem_ambi iem_bin_ambi iemguts iem_adaptfilt iem_delay iem_roomsim iem_spec2 jasch_lib loaders-libdir mapping markex maxlib mjlib moonlib motex mrpeach pan pddp rjlib plugin pmpd sigpack smlib tof unauthorized vbap windowing
-lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone earplug ekext ext13 fftease flatgui freeverb ggee hcs jasch_lib loaders-libdir lyonpotpourri mapping markex maxlib mjlib moonlib motex mrpeach oscx pan pddp pdogg rjlib plugin pmpd sigpack smlib tof unauthorized vbap windowing
+lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui freeverb ggee hcs iemlib iemgui iemguts jasch_lib loaders-libdir lyonpotpourri mapping markex maxlib mjlib moonlib motex mrpeach oscx pan pdcontainer pddp pdogg rjlib plugin pmpd sigpack smlib tof unauthorized vbap windowing
 # short one for quick building for debugging purposes (disabled by default):
 # lib_targets = maxlib
 else
@@ -527,6 +527,7 @@ endif
 
 #------------------------------------------------------------------------------#
 # DISIS
+ifneq ($(EMSCRIPTEN),yes)
 disis:
 ifneq ($(OS_NAME),windows)
 ifneq ($(OS_NAME),darwin)
@@ -558,6 +559,13 @@ ifneq ($(OS_NAME),darwin)
 endif
 endif
 	make -C $(externals_src)/disis clean
+else
+disis:
+
+disis_install:
+	install -d $(DESTDIR)$(objectsdir)/disis
+	install -p $(externals_src)/disis/*.pd $(DESTDIR)$(objectsdir)/disis
+endif
 
 #------------------------------------------------------------------------------#
 # EKEXT
@@ -1010,6 +1018,13 @@ hidin_clean:
 	-rm -f -- $(externals_src)/olafmatt/hidin/*.*~
 
 
+#------------------------------------------------------------------------------#
+# General IEM flags
+ifeq ($(EMSCRIPTEN),yes)
+IEM_FLAGS=-D__linux__ -Wno-incompatible-pointer-types
+else
+IEM_FLAGS=-O2
+endif
 
 #------------------------------------------------------------------------------#
 # IEM_AMBI
@@ -1127,6 +1142,13 @@ IEMGUTS_NAME=iemguts
 IEMGUTS_OBJECTS := $(wildcard $(externals_src)/iem/iemguts/src/*.c)
 iemguts: $(IEMGUTS_OBJECTS:.c=.$(EXTENSION))
 
+ifeq ($(EMSCRIPTEN),yes)
+$(IEMGUTS_OBJECTS:.c=.o) : $(IEMGUTS_OBJECTS)
+	$(CC) $(CFLAGS) $(IEM_FLAGS) -funroll-loops -fomit-frame-pointer -fno-tree-vectorize -fno-strict-aliasing -o "$*.o" -c "$*.c"
+
+$(IEMGUTS_OBJECTS:.c=.$(EXTENSION)) : $(IEMGUTS_OBJECTS:.c=.o)
+	$(CC) $(LDFLAGS) $(IEM_FLAGS) -o "$*.${EXTENSION}" "$*.o"
+endif
 
 iemguts_install: iemguts
 	install -d $(DESTDIR)$(objectsdir)/$(IEMGUTS_NAME)
@@ -1160,7 +1182,7 @@ IEMLIB_SRC := $(wildcard $(externals_src)/iemlib/iemlib1/src/*[^1].c) $(wildcard
 
 IEMLIB_OBJECTS := $(IEMLIB_SRC:.c=.o)
 $(IEMLIB_OBJECTS) : %.o : %.c
-	$(CC) -I$(externals_src)/iemlib/include $(CFLAGS) -O2 -funroll-loops -fomit-frame-pointer -fno-tree-vectorize -fno-strict-aliasing -o "$*.o" -c "$*.c"
+	$(CC) -I$(externals_src)/iemlib/include $(CFLAGS) $(IEM_FLAGS) -funroll-loops -fomit-frame-pointer -fno-tree-vectorize -fno-strict-aliasing -o "$*.o" -c "$*.c"
 
 iemlib: $(IEMLIB_SRC:.c=.$(EXTENSION))
 
@@ -2234,7 +2256,11 @@ $(PDCONTAINER_TARGETS) : %.$(EXTENSION) : $(PDCONTAINER_OBJ)
 #	rm -f -- "$*.o"
 
 $(PDCONTAINER_OBJ) : %.o : %.cpp
+ifeq ($(EMSCRIPTEN),yes)
+	$(CXX) $(CXXFLAGS) -DPDCONTAINER_SINGLE_OBJECT $(PDCONTAINER_INCLUDE) -std=c++98 -o "$*.o" -c "$*.cpp"
+else
 	$(CXX) $(CXXFLAGS) -DPDCONTAINER_SINGLE_OBJECT $(PDCONTAINER_INCLUDE) -o "$*.o" -c "$*.cpp"
+endif
 
 pdcontainer_install: pdcontainer
 	install -d $(DESTDIR)$(objectsdir)/$(PDCONTAINER_NAME)
@@ -2557,6 +2583,7 @@ IEMGUI_FLAGS := -DIEMGUI_SINGLE_OBJ
 
 iemgui: $(IEMGUI_TARGETS)
 
+ifeq ($(EMSCRIPTEN),no)
 $(IEMGUI_TARGETS) : %.$(EXTENSION) : %.o $(IEMGUI_OBJ)
 	$(CC) $(LDFLAGS) $(IEMGUI_FLATPAK_LINKER_FLAGS) -o $*.$(EXTENSION) "$*.o" $(externals_src)/iem/iemgui/src/iemgui.o $(LIBS)
 	$(STRIP) $*.$(EXTENSION)
@@ -2565,6 +2592,13 @@ $(IEMGUI_TARGETS) : %.$(EXTENSION) : %.o $(IEMGUI_OBJ)
 
 $(IEMGUI_OBJ) : %.o : %.c
 	$(CC) $(CFLAGS) $(IEMGUI_FLAGS) -o "$*.o" -c "$*.c"
+else
+$(IEMGUI_OBJ): $(IEMGUI_SRC)
+	$(CC) $(CFLAGS) $(IEM_FLAGS) $(IEMGUI_FLAGS) -o "$*.o" -c "$*.c"
+
+$(IEMGUI_TARGETS): $(IEMGUI_OBJ)
+	$(CC) $(LDFLAGS) $(IEM_FLAGS) $(IEMGUI_FLAGS) -o $*.$(EXTENSION) $*.o $(externals_src)/iem/iemgui/src/iemgui.o $(LIBS)
+endif
 
 iemgui_install: iemgui
 	install -d $(DESTDIR)$(objectsdir)/$(IEMGUI_NAME)

--- a/externals/autotune/autotune~.c
+++ b/externals/autotune/autotune~.c
@@ -237,7 +237,11 @@ void *autotune_new(t_symbol *s, int argc, t_atom *argv);
 void autotune_free(t_autotune *x);	
 void autotune_init(t_autotune *x, unsigned long sr);
 t_int *autotune_perform(t_int *w);
+#ifndef __EMSCRIPTEN__
 void autotune_dsp(t_autotune *x, t_signal **sp, short *count);
+#else
+void autotune_dsp(t_autotune *x, t_signal **sp);
+#endif
 void autotune_assist(t_autotune *x, void *b, long m, long a, char *s);
 //void autotune_setparam(t_autotune *x, t_symbol *m, short argc, t_atom *argv);
 void autotune_list(t_autotune *x, t_symbol *m, short argc, t_atom *argv);
@@ -541,7 +545,11 @@ void autotune_init(t_autotune *x,unsigned long sr)
 // DSP Methods PD //
 //*********************//
 
+#ifndef __EMSCRIPTEN__
 void autotune_dsp(t_autotune *x, t_signal **sp, short *count)
+#else
+void autotune_dsp(t_autotune *x, t_signal **sp)
+#endif
 {
 	clock_delay(x->clock, 0.);
 	

--- a/externals/ggee/gui/image.c
+++ b/externals/ggee/gui/image.c
@@ -112,7 +112,11 @@ t_symbol *image_trytoopen(t_image* x)
     }
 }
 
+#ifndef __EMSCRIPTEN__
 extern char *gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#else
+extern void gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#endif
 
 static void image_drawme(t_gobj *client, t_glist *glist)
 {

--- a/externals/grh/PDContainer/src/h_deque.cpp
+++ b/externals/grh/PDContainer/src/h_deque.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_DEFFLOAT
-#endif
 
 static t_class *h_deque_class;
 static t_class *proxy_class;
@@ -568,33 +563,33 @@ void h_deque_setup(void)
   class_addmethod(h_deque_class, (t_method)h_deque_push_back, 
 		  gensym("pushback"), A_GIMME, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_pop_back, 
-		  gensym("popback"), A_EMPTY, 0);
+		  gensym("popback"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_back, 
-		  gensym("back"), A_EMPTY, 0);
+		  gensym("back"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_push_front, 
 		  gensym("pushfront"), A_GIMME, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_pop_front, 
-		  gensym("popfront"), A_EMPTY, 0);
+		  gensym("popfront"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_front, 
-		  gensym("front"), A_EMPTY, 0);
+		  gensym("front"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_remove, 
 		  gensym("remove"), A_GIMME, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_resize, 
 		  gensym("resize"), A_GIMME , 0);
   class_addmethod(h_deque_class, (t_method)h_deque_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_deque_class, (t_method)h_deque_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_deque_class, (t_method)h_deque_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_getall,
-		  gensym("getall"), A_EMPTY, 0);
+		  gensym("getall"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_print,
-		  gensym("print"), A_EMPTY, 0);
+		  gensym("print"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_save, 
 		  gensym("save"), A_DEFSYMBOL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_read, 
@@ -609,7 +604,7 @@ void h_deque_setup(void)
 		  gensym("readatXML"), A_GIMME, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_deque_class, (t_method)h_deque_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_deque_class, (t_method)h_deque_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_deque.cpp
+++ b/externals/grh/PDContainer/src/h_deque.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HDeque.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_DEFFLOAT
+#endif
 
 static t_class *h_deque_class;
 static t_class *proxy_class;
@@ -538,12 +547,6 @@ static void *h_deque_free(t_h_deque *x)
   return (void *)x;
 }
 
-
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_deque_setup(void) 
 {
   // the object class
@@ -565,33 +568,33 @@ void h_deque_setup(void)
   class_addmethod(h_deque_class, (t_method)h_deque_push_back, 
 		  gensym("pushback"), A_GIMME, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_pop_back, 
-		  gensym("popback"), A_DEFFLOAT, 0);
+		  gensym("popback"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_back, 
-		  gensym("back"), A_DEFFLOAT, 0);
+		  gensym("back"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_push_front, 
 		  gensym("pushfront"), A_GIMME, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_pop_front, 
-		  gensym("popfront"), A_DEFFLOAT, 0);
+		  gensym("popfront"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_front, 
-		  gensym("front"), A_DEFFLOAT, 0);
+		  gensym("front"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_remove, 
 		  gensym("remove"), A_GIMME, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_resize, 
 		  gensym("resize"), A_GIMME , 0);
   class_addmethod(h_deque_class, (t_method)h_deque_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_deque_class, (t_method)h_deque_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_deque_class, (t_method)h_deque_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_getall,
-		  gensym("getall"), A_DEFFLOAT, 0);
+		  gensym("getall"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_print,
-		  gensym("print"), A_DEFFLOAT, 0);
+		  gensym("print"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_save, 
 		  gensym("save"), A_DEFSYMBOL, 0);
   class_addmethod(h_deque_class, (t_method)h_deque_read, 
@@ -606,7 +609,7 @@ void h_deque_setup(void)
 		  gensym("readatXML"), A_GIMME, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_deque_class, (t_method)h_deque_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_deque_class, (t_method)h_deque_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_list.cpp
+++ b/externals/grh/PDContainer/src/h_list.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HList.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_DEFFLOAT
+#endif
 
 static t_class *h_list_class;
 
@@ -393,11 +402,6 @@ static void *h_list_free(t_h_list *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_list_setup(void) 
 {
   // the object class
@@ -408,17 +412,17 @@ void h_list_setup(void)
   class_addmethod(h_list_class, (t_method)h_list_push_back, 
 		  gensym("pushback"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_pop_back, 
-		  gensym("popback"), A_DEFFLOAT, 0);
+		  gensym("popback"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_push_front, 
 		  gensym("pushfront"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_pop_front, 
-		  gensym("popfront"), A_DEFFLOAT, 0);
+		  gensym("popfront"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_back, 
-		  gensym("back"), A_DEFFLOAT, 0);
+		  gensym("back"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_front, 
-		  gensym("front"), A_DEFFLOAT, 0);
+		  gensym("front"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_get, 
-		  gensym("get"), A_DEFFLOAT, 0);
+		  gensym("get"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_insert, 
 		  gensym("insert"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_modify, 
@@ -426,39 +430,39 @@ void h_list_setup(void)
   class_addmethod(h_list_class, (t_method)h_list_remove, 
 		  gensym("remove"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_delete, 
-		  gensym("delete"), A_DEFFLOAT, 0);
+		  gensym("delete"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_list_class, (t_method)h_list_get_iter_pos, 
-		  gensym("getiter"), A_DEFFLOAT , 0);
+		  gensym("getiter"), A_EMPTY , 0);
   class_addmethod(h_list_class, (t_method)h_list_set_iter_pos, 
-		  gensym("setiter"), A_DEFFLOAT , 0);
+		  gensym("setiter"), A_EMPTY , 0);
   class_addmethod(h_list_class, (t_method)h_list_begin, 
-		  gensym("begin"), A_DEFFLOAT, 0);
+		  gensym("begin"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_end, 
-		  gensym("end"), A_DEFFLOAT, 0);
+		  gensym("end"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_next, 
-		  gensym("next"), A_DEFFLOAT, 0);
+		  gensym("next"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_last, 
-		  gensym("last"), A_DEFFLOAT, 0);
+		  gensym("last"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_unique, 
-		  gensym("unique"), A_DEFFLOAT, 0);
+		  gensym("unique"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_reverse, 
-		  gensym("reverse"), A_DEFFLOAT, 0);
+		  gensym("reverse"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_sort, 
-		  gensym("sort"), A_DEFFLOAT, 0);
+		  gensym("sort"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_list_class, (t_method)h_list_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_getall,
-		  gensym("getall"), A_DEFFLOAT, 0);
+		  gensym("getall"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_print,
-		  gensym("print"), A_DEFFLOAT, 0);
+		  gensym("print"), A_EMPTY, 0);
   class_addmethod(h_list_class, (t_method)h_list_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_list_class, (t_method)h_list_read, 
@@ -469,7 +473,7 @@ void h_list_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_list_class, (t_method)h_list_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_list_class, (t_method)h_list_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_list.cpp
+++ b/externals/grh/PDContainer/src/h_list.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_DEFFLOAT
-#endif
 
 static t_class *h_list_class;
 
@@ -412,17 +407,17 @@ void h_list_setup(void)
   class_addmethod(h_list_class, (t_method)h_list_push_back, 
 		  gensym("pushback"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_pop_back, 
-		  gensym("popback"), A_EMPTY, 0);
+		  gensym("popback"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_push_front, 
 		  gensym("pushfront"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_pop_front, 
-		  gensym("popfront"), A_EMPTY, 0);
+		  gensym("popfront"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_back, 
-		  gensym("back"), A_EMPTY, 0);
+		  gensym("back"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_front, 
-		  gensym("front"), A_EMPTY, 0);
+		  gensym("front"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_get, 
-		  gensym("get"), A_EMPTY, 0);
+		  gensym("get"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_insert, 
 		  gensym("insert"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_modify, 
@@ -430,39 +425,39 @@ void h_list_setup(void)
   class_addmethod(h_list_class, (t_method)h_list_remove, 
 		  gensym("remove"), A_GIMME, 0);
   class_addmethod(h_list_class, (t_method)h_list_delete, 
-		  gensym("delete"), A_EMPTY, 0);
+		  gensym("delete"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_list_class, (t_method)h_list_get_iter_pos, 
-		  gensym("getiter"), A_EMPTY , 0);
+		  gensym("getiter"), A_NULL , 0);
   class_addmethod(h_list_class, (t_method)h_list_set_iter_pos, 
-		  gensym("setiter"), A_EMPTY , 0);
+		  gensym("setiter"), A_NULL , 0);
   class_addmethod(h_list_class, (t_method)h_list_begin, 
-		  gensym("begin"), A_EMPTY, 0);
+		  gensym("begin"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_end, 
-		  gensym("end"), A_EMPTY, 0);
+		  gensym("end"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_next, 
-		  gensym("next"), A_EMPTY, 0);
+		  gensym("next"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_last, 
-		  gensym("last"), A_EMPTY, 0);
+		  gensym("last"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_unique, 
-		  gensym("unique"), A_EMPTY, 0);
+		  gensym("unique"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_reverse, 
-		  gensym("reverse"), A_EMPTY, 0);
+		  gensym("reverse"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_sort, 
-		  gensym("sort"), A_EMPTY, 0);
+		  gensym("sort"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_list_class, (t_method)h_list_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_getall,
-		  gensym("getall"), A_EMPTY, 0);
+		  gensym("getall"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_print,
-		  gensym("print"), A_EMPTY, 0);
+		  gensym("print"), A_NULL, 0);
   class_addmethod(h_list_class, (t_method)h_list_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_list_class, (t_method)h_list_read, 
@@ -473,7 +468,7 @@ void h_list_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_list_class, (t_method)h_list_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_list_class, (t_method)h_list_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_map.cpp
+++ b/externals/grh/PDContainer/src/h_map.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_DEFFLOAT
-#endif
 
 static t_class *h_map_class;
 static t_class *proxy_class;
@@ -366,21 +361,21 @@ void h_map_setup(void)
   class_addmethod(h_map_class, (t_method)h_map_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_map_class, (t_method)h_map_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_map_class, (t_method)h_map_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_map_class, (t_method)h_map_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_map_class, (t_method)h_map_keys,
-		  gensym("keys"), A_EMPTY, 0);
+		  gensym("keys"), A_NULL, 0);
   class_addmethod(h_map_class, (t_method)h_map_values,
-		  gensym("values"), A_EMPTY, 0);
+		  gensym("values"), A_NULL, 0);
   class_addmethod(h_map_class, (t_method)h_map_print,
-		  gensym("print"), A_EMPTY, 0);
+		  gensym("print"), A_NULL, 0);
   class_addmethod(h_map_class, (t_method)h_map_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_map_class, (t_method)h_map_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
   class_addmethod(h_map_class, (t_method)h_map_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_map_class, (t_method)h_map_save_xml, 
@@ -391,7 +386,7 @@ void h_map_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_map_class, (t_method)h_map_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_map_class, (t_method)h_map_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_map.cpp
+++ b/externals/grh/PDContainer/src/h_map.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HMap.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_DEFFLOAT
+#endif
 
 static t_class *h_map_class;
 static t_class *proxy_class;
@@ -338,11 +347,6 @@ static void *h_map_free(t_h_map *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_map_setup(void) 
 {
   // the object class
@@ -362,21 +366,21 @@ void h_map_setup(void)
   class_addmethod(h_map_class, (t_method)h_map_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_map_class, (t_method)h_map_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_map_class, (t_method)h_map_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_map_class, (t_method)h_map_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_map_class, (t_method)h_map_keys,
-		  gensym("keys"), A_DEFFLOAT, 0);
+		  gensym("keys"), A_EMPTY, 0);
   class_addmethod(h_map_class, (t_method)h_map_values,
-		  gensym("values"), A_DEFFLOAT, 0);
+		  gensym("values"), A_EMPTY, 0);
   class_addmethod(h_map_class, (t_method)h_map_print,
-		  gensym("print"), A_DEFFLOAT, 0);
+		  gensym("print"), A_EMPTY, 0);
   class_addmethod(h_map_class, (t_method)h_map_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_map_class, (t_method)h_map_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
   class_addmethod(h_map_class, (t_method)h_map_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_map_class, (t_method)h_map_save_xml, 
@@ -387,7 +391,7 @@ void h_map_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_map_class, (t_method)h_map_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_map_class, (t_method)h_map_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_multimap.cpp
+++ b/externals/grh/PDContainer/src/h_multimap.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HMultiMap.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_EMPTY
+#endif
 
 static t_class *h_multimap_class;
 static t_class *proxy_class;
@@ -335,11 +344,6 @@ static void *h_multimap_free(t_h_multimap *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_multimap_setup(void) 
 {
   h_multimap_class = class_new(gensym("h_multimap"), (t_newmethod)h_multimap_new,
@@ -358,21 +362,21 @@ void h_multimap_setup(void)
   class_addmethod(h_multimap_class, (t_method)h_multimap_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_keys,
-		  gensym("keys"), A_DEFFLOAT, 0);
+		  gensym("keys"), A_EMPTY, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_values,
-		  gensym("values"), A_DEFFLOAT, 0);
+		  gensym("values"), A_EMPTY, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_print,
-		  gensym("print"), A_DEFFLOAT, 0);
+		  gensym("print"), A_EMPTY, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_save_xml, 
@@ -384,7 +388,7 @@ void h_multimap_setup(void)
 
   // without an argument the following two methods wont work ??? why?? because of c++?
   class_addmethod(h_multimap_class, (t_method)h_multimap_help, 
-		  gensym("help"),A_DEFFLOAT, 0);
+		  gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_multimap.cpp
+++ b/externals/grh/PDContainer/src/h_multimap.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_EMPTY
-#endif
 
 static t_class *h_multimap_class;
 static t_class *proxy_class;
@@ -362,21 +357,21 @@ void h_multimap_setup(void)
   class_addmethod(h_multimap_class, (t_method)h_multimap_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_keys,
-		  gensym("keys"), A_EMPTY, 0);
+		  gensym("keys"), A_NULL, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_values,
-		  gensym("values"), A_EMPTY, 0);
+		  gensym("values"), A_NULL, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_print,
-		  gensym("print"), A_EMPTY, 0);
+		  gensym("print"), A_NULL, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_multimap_class, (t_method)h_multimap_save_xml, 
@@ -388,7 +383,7 @@ void h_multimap_setup(void)
 
   // without an argument the following two methods wont work ??? why?? because of c++?
   class_addmethod(h_multimap_class, (t_method)h_multimap_help, 
-		  gensym("help"),A_EMPTY, 0);
+		  gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_multiset.cpp
+++ b/externals/grh/PDContainer/src/h_multiset.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HMultiSet.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_EMPTY
+#endif
 
 static t_class *h_multiset_class;
 
@@ -205,11 +214,6 @@ static void *h_multiset_free(t_h_multiset *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_multiset_setup(void) 
 {
   // the object class
@@ -224,19 +228,19 @@ void h_multiset_setup(void)
   class_addmethod(h_multiset_class, (t_method)h_multiset_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_getall,
-		  gensym("getall"), A_DEFFLOAT, 0);
+		  gensym("getall"), A_EMPTY, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_print,
-		  gensym("print"), A_DEFFLOAT, 0);
+		  gensym("print"), A_EMPTY, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_read, 
@@ -247,7 +251,7 @@ void h_multiset_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_multiset_class, (t_method)h_multiset_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_multiset_class, (t_method)h_multiset_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_multiset.cpp
+++ b/externals/grh/PDContainer/src/h_multiset.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_EMPTY
-#endif
 
 static t_class *h_multiset_class;
 
@@ -228,19 +223,19 @@ void h_multiset_setup(void)
   class_addmethod(h_multiset_class, (t_method)h_multiset_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_getall,
-		  gensym("getall"), A_EMPTY, 0);
+		  gensym("getall"), A_NULL, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_print,
-		  gensym("print"), A_EMPTY, 0);
+		  gensym("print"), A_NULL, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_multiset_class, (t_method)h_multiset_read, 
@@ -251,7 +246,7 @@ void h_multiset_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_multiset_class, (t_method)h_multiset_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_multiset_class, (t_method)h_multiset_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_prioqueue.cpp
+++ b/externals/grh/PDContainer/src/h_prioqueue.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_EMPTY
-#endif
 
 static t_class *h_prioqueue_class;
 static t_class *proxy_class;
@@ -240,22 +235,22 @@ void h_prioqueue_setup(void)
 		  gensym("push"), A_GIMME, 0);
   class_addanything(proxy_class, (t_method)h_prioqueue_value); // the right inlet
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_pop, 
-		  gensym("pop"), A_EMPTY, 0);
+		  gensym("pop"), A_NULL, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_top, 
-		  gensym("top"), A_EMPTY, 0);
+		  gensym("top"), A_NULL, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_prioqueue.cpp
+++ b/externals/grh/PDContainer/src/h_prioqueue.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HPrioQueue.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_EMPTY
+#endif
 
 static t_class *h_prioqueue_class;
 static t_class *proxy_class;
@@ -216,11 +225,6 @@ static void *h_prioqueue_free(t_h_prioqueue *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_prioqueue_setup(void) 
 {
   // the object class
@@ -236,22 +240,22 @@ void h_prioqueue_setup(void)
 		  gensym("push"), A_GIMME, 0);
   class_addanything(proxy_class, (t_method)h_prioqueue_value); // the right inlet
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_pop, 
-		  gensym("pop"), A_DEFFLOAT, 0);
+		  gensym("pop"), A_EMPTY, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_top, 
-		  gensym("top"), A_DEFFLOAT, 0);
+		  gensym("top"), A_EMPTY, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_prioqueue_class, (t_method)h_prioqueue_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_queue.cpp
+++ b/externals/grh/PDContainer/src/h_queue.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HQueue.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_DEFFLOAT
+#endif
 
 static t_class *h_queue_class;
 
@@ -136,11 +145,6 @@ static void *h_queue_free(t_h_queue *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_queue_setup(void) 
 {
   // the object class
@@ -151,22 +155,22 @@ void h_queue_setup(void)
   class_addmethod(h_queue_class, (t_method)h_queue_push, 
 		  gensym("push"), A_GIMME, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_pop, 
-		  gensym("pop"), A_DEFFLOAT, 0);
+		  gensym("pop"), A_EMPTY, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_front, 
-		  gensym("front"), A_DEFFLOAT, 0);
+		  gensym("front"), A_EMPTY, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_queue_class, (t_method)h_queue_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_queue_class, (t_method)h_queue_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_queue_class, (t_method)h_queue_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_queue_class, (t_method)h_queue_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_queue.cpp
+++ b/externals/grh/PDContainer/src/h_queue.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_DEFFLOAT
-#endif
 
 static t_class *h_queue_class;
 
@@ -155,22 +150,22 @@ void h_queue_setup(void)
   class_addmethod(h_queue_class, (t_method)h_queue_push, 
 		  gensym("push"), A_GIMME, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_pop, 
-		  gensym("pop"), A_EMPTY, 0);
+		  gensym("pop"), A_NULL, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_front, 
-		  gensym("front"), A_EMPTY, 0);
+		  gensym("front"), A_NULL, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_queue_class, (t_method)h_queue_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_queue_class, (t_method)h_queue_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_queue_class, (t_method)h_queue_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_queue_class, (t_method)h_queue_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_queue_class, (t_method)h_queue_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_set.cpp
+++ b/externals/grh/PDContainer/src/h_set.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_EMPTY
-#endif
 
 static t_class *h_set_class;
 
@@ -228,19 +223,19 @@ void h_set_setup(void)
   class_addmethod(h_set_class, (t_method)h_set_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_set_class, (t_method)h_set_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_set_class, (t_method)h_set_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_set_class, (t_method)h_set_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_set_class, (t_method)h_set_getall,
-		  gensym("getall"), A_EMPTY, 0);
+		  gensym("getall"), A_NULL, 0);
   class_addmethod(h_set_class, (t_method)h_set_print,
-		  gensym("print"), A_EMPTY, 0);
+		  gensym("print"), A_NULL, 0);
   class_addmethod(h_set_class, (t_method)h_set_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_set_class, (t_method)h_set_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
   class_addmethod(h_set_class, (t_method)h_set_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_set_class, (t_method)h_set_read, 
@@ -251,7 +246,7 @@ void h_set_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_set_class, (t_method)h_set_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_set_class, (t_method)h_set_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_set.cpp
+++ b/externals/grh/PDContainer/src/h_set.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HSet.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_EMPTY
+#endif
 
 static t_class *h_set_class;
 
@@ -205,11 +214,6 @@ static void *h_set_free(t_h_set *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_set_setup(void) 
 {
   // the object class
@@ -224,19 +228,19 @@ void h_set_setup(void)
   class_addmethod(h_set_class, (t_method)h_set_remove, 
 		  gensym("remove"), A_GIMME , 0);
   class_addmethod(h_set_class, (t_method)h_set_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_set_class, (t_method)h_set_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_set_class, (t_method)h_set_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_set_class, (t_method)h_set_getall,
-		  gensym("getall"), A_DEFFLOAT, 0);
+		  gensym("getall"), A_EMPTY, 0);
   class_addmethod(h_set_class, (t_method)h_set_print,
-		  gensym("print"), A_DEFFLOAT, 0);
+		  gensym("print"), A_EMPTY, 0);
   class_addmethod(h_set_class, (t_method)h_set_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_set_class, (t_method)h_set_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
   class_addmethod(h_set_class, (t_method)h_set_save, 
 		  gensym("save"), A_DEFSYMBOL , 0);
   class_addmethod(h_set_class, (t_method)h_set_read, 
@@ -247,7 +251,7 @@ void h_set_setup(void)
 		  gensym("readXML"), A_DEFSYMBOL , 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_set_class, (t_method)h_set_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_set_class, (t_method)h_set_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_stack.cpp
+++ b/externals/grh/PDContainer/src/h_stack.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_EMPTY
-#endif
 
 static t_class *h_stack_class;
 
@@ -155,22 +150,22 @@ void h_stack_setup(void)
   class_addmethod(h_stack_class, (t_method)h_stack_push, 
 		  gensym("push"), A_GIMME, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_pop, 
-		  gensym("pop"), A_EMPTY, 0);
+		  gensym("pop"), A_NULL, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_top, 
-		  gensym("top"), A_EMPTY, 0);
+		  gensym("top"), A_NULL, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_stack_class, (t_method)h_stack_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_stack_class, (t_method)h_stack_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_stack_class, (t_method)h_stack_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_stack_class, (t_method)h_stack_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_stack.cpp
+++ b/externals/grh/PDContainer/src/h_stack.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HStack.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_EMPTY
+#endif
 
 static t_class *h_stack_class;
 
@@ -136,11 +145,6 @@ static void *h_stack_free(t_h_stack *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_stack_setup(void) 
 {
   // the object class
@@ -151,22 +155,22 @@ void h_stack_setup(void)
   class_addmethod(h_stack_class, (t_method)h_stack_push, 
 		  gensym("push"), A_GIMME, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_pop, 
-		  gensym("pop"), A_DEFFLOAT, 0);
+		  gensym("pop"), A_EMPTY, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_top, 
-		  gensym("top"), A_DEFFLOAT, 0);
+		  gensym("top"), A_EMPTY, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_stack_class, (t_method)h_stack_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_stack_class, (t_method)h_stack_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_stack_class, (t_method)h_stack_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_stack_class, (t_method)h_stack_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_stack_class, (t_method)h_stack_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_vector.cpp
+++ b/externals/grh/PDContainer/src/h_vector.cpp
@@ -13,6 +13,15 @@
 
 #include "include/HVector.h"
 
+#if defined(PDCONTAINER_SINGLE_OBJECT)
+// for PD-Extended
+extern "C" {
+#endif
+#ifdef __EMSCRIPTEN__
+#define A_EMPTY A_NULL
+#else
+#define A_EMPTY A_EMPTY
+#endif
 
 static t_class *h_vector_class;
 static t_class *proxy_class;
@@ -456,11 +465,6 @@ static void *h_vector_free(t_h_vector *x)
   return (void *)x;
 }
 
-#if defined(PDCONTAINER_SINGLE_OBJECT)
-// for PD-Extended
-extern "C" {
-#endif
-
 void h_vector_setup(void) 
 {
   // the object class
@@ -482,25 +486,25 @@ void h_vector_setup(void)
   class_addmethod(h_vector_class, (t_method)h_vector_get, 
 		  gensym("get"), A_GIMME, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_pop_back, 
-		  gensym("popback"), A_DEFFLOAT, 0);
+		  gensym("popback"), A_EMPTY, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_remove, 
 		  gensym("remove"), A_GIMME, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_resize, 
 		  gensym("resize"), A_GIMME , 0);
   class_addmethod(h_vector_class, (t_method)h_vector_getsize, 
-		  gensym("getsize"), A_DEFFLOAT , 0);
+		  gensym("getsize"), A_EMPTY , 0);
   class_addmethod(h_vector_class, (t_method)h_vector_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_vector_class, (t_method)h_vector_get_namespace, 
-		  gensym("getnamespace"), A_DEFFLOAT, 0);
+		  gensym("getnamespace"), A_EMPTY, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_getall,
-		  gensym("getall"), A_DEFFLOAT, 0);
+		  gensym("getall"), A_EMPTY, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_print,
-		  gensym("print"), A_DEFFLOAT, 0);
+		  gensym("print"), A_EMPTY, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_clear,  
-		  gensym("clear"), A_DEFFLOAT, 0);
+		  gensym("clear"), A_EMPTY, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_clear_all,  
-		  gensym("clearall"), A_DEFFLOAT, 0);
+		  gensym("clearall"), A_EMPTY, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_save, 
 		  gensym("save"), A_DEFSYMBOL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_read, 
@@ -515,7 +519,7 @@ void h_vector_setup(void)
 		  gensym("readatXML"), A_GIMME, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_vector_class, (t_method)h_vector_help, gensym("help"),A_DEFFLOAT, 0);
+  class_addmethod(h_vector_class, (t_method)h_vector_help, gensym("help"),A_EMPTY, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/grh/PDContainer/src/h_vector.cpp
+++ b/externals/grh/PDContainer/src/h_vector.cpp
@@ -17,11 +17,6 @@
 // for PD-Extended
 extern "C" {
 #endif
-#ifdef __EMSCRIPTEN__
-#define A_EMPTY A_NULL
-#else
-#define A_EMPTY A_EMPTY
-#endif
 
 static t_class *h_vector_class;
 static t_class *proxy_class;
@@ -486,25 +481,25 @@ void h_vector_setup(void)
   class_addmethod(h_vector_class, (t_method)h_vector_get, 
 		  gensym("get"), A_GIMME, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_pop_back, 
-		  gensym("popback"), A_EMPTY, 0);
+		  gensym("popback"), A_NULL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_remove, 
 		  gensym("remove"), A_GIMME, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_resize, 
 		  gensym("resize"), A_GIMME , 0);
   class_addmethod(h_vector_class, (t_method)h_vector_getsize, 
-		  gensym("getsize"), A_EMPTY , 0);
+		  gensym("getsize"), A_NULL , 0);
   class_addmethod(h_vector_class, (t_method)h_vector_set_namespace, 
 		  gensym("namespace"), A_DEFSYMBOL , 0);
   class_addmethod(h_vector_class, (t_method)h_vector_get_namespace, 
-		  gensym("getnamespace"), A_EMPTY, 0);
+		  gensym("getnamespace"), A_NULL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_getall,
-		  gensym("getall"), A_EMPTY, 0);
+		  gensym("getall"), A_NULL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_print,
-		  gensym("print"), A_EMPTY, 0);
+		  gensym("print"), A_NULL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_clear,  
-		  gensym("clear"), A_EMPTY, 0);
+		  gensym("clear"), A_NULL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_clear_all,  
-		  gensym("clearall"), A_EMPTY, 0);
+		  gensym("clearall"), A_NULL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_save, 
 		  gensym("save"), A_DEFSYMBOL, 0);
   class_addmethod(h_vector_class, (t_method)h_vector_read, 
@@ -519,7 +514,7 @@ void h_vector_setup(void)
 		  gensym("readatXML"), A_GIMME, 0);
 
   // without an argument the following two methods wont work ??? why?? because of c++?
-  class_addmethod(h_vector_class, (t_method)h_vector_help, gensym("help"),A_EMPTY, 0);
+  class_addmethod(h_vector_class, (t_method)h_vector_help, gensym("help"),A_NULL, 0);
 }
 
 #if defined(PDCONTAINER_SINGLE_OBJECT)

--- a/externals/pddp/helplink.c
+++ b/externals/pddp/helplink.c
@@ -129,7 +129,11 @@ static void helplink_activate(t_gobj *z, t_glist *glist, int state)
     }
 }
 
+#ifndef __EMSCRIPTEN__
 extern char *gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#else
+extern void gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#endif
 
 static void helplink_vis(t_gobj *z, t_glist *glist, int vis)
 {

--- a/externals/pddp/pddplink.c
+++ b/externals/pddp/pddplink.c
@@ -114,7 +114,11 @@ static void pddplink_select(t_gobj *z, t_glist *glist, int state)
     }
 }
 
+#ifndef __EMSCRIPTEN__
 extern char *gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#else
+extern void gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#endif
 
 static void pddplink_vis(t_gobj *z, t_glist *glist, int vis)
 {

--- a/externals/tof/src/imagebang.c
+++ b/externals/tof/src/imagebang.c
@@ -163,7 +163,11 @@ static int imagebang_click(t_imagebang *x, struct _glist *glist,
     return (1);
 }
 
+#ifndef __EMSCRIPTEN__
 extern char *gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#else
+extern void gobj_vis_gethelpname(t_gobj *z, char *namebuf);
+#endif
 
 static void imagebang_drawme(t_imagebang *x, t_glist *glist, int firsttime)
 {

--- a/pdwebparty.Dockerfile
+++ b/pdwebparty.Dockerfile
@@ -3,7 +3,7 @@ FROM emscripten/emsdk AS builder
 WORKDIR /pd-l2ork/
 RUN apt-get update && apt-get upgrade -y && apt-get install -y autoconf
 COPY . .
-RUN cd emscripten; make
+RUN cd emscripten; make clean; make
 
 # Create container used to run PdWebParty (without the bloat of all the build tools)
 FROM node:current-alpine


### PR DESCRIPTION
- Parallelize loading of abstractions
- Allow shift-dragging sliders
- Allow shift-dragging knobs
- Build patch_name from disis
- Build iemlib
- Build iemgui
- Build iemguts
- Build pdcontainer
- Fix pdWebParty docker not building properly on a dirty tree
- Fix editing arrays on firefox
- Fix editing arrays on touch screen
- Fix autotune
- Fix errors from ggeeimage
- Fix errors from pddplink
- Fix antialiasing of knobs/bangs
- Fix onKeyUp behavior
- Fix infinite loop for infinite recursion of subpatches
- Fix legacy mouse objects in subpatches
- Fix arrays overlapping border
- Fix message not displaying on subpatches and abstractions