### PR TITLE
WebPdL2Ork Work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "3000:3000"
     environment:
       - PORT=3000
+      - PATCH_PATH=public/patches
     volumes:
       - ./emscripten/projects/WebPdL2Ork/public:/WebPdL2Ork/public/patches:ro
     restart: unless-stopped

--- a/emscripten/DOCUMENTATION.md
+++ b/emscripten/DOCUMENTATION.md
@@ -1,15 +1,42 @@
 # Authors (listed alphabetically)
-Drew Bowman <drewb00@vt.edu>
-Ivica Ico Bukvic <ico@vt.edu>
-William Furgerson <williamfurgerson@vt.edu>
-Zack Lee <cuinjune@gmail.com>
+Drew Bowman <drewb00@vt.edu>  
+Ivica Ico Bukvic <ico@vt.edu>  
+William Furgerson <williamfurgerson@vt.edu>  
+Zack Lee <cuinjune@gmail.com>  
 
 With contributions from Jonathan Wilkes and Albert Graef
 
 # Overview
 WebPdL2Ork is a Pd-L2Ork implementation and further development of the [PdWebParty] (https://github.com/cuinjune/PdWebParty) poject, originally introduced as part of the Google Summer of Code. WebPdL2Ork is a system for automatic generation of embeddable library from the code snippets made in the Pd-L2Ork visual programming environment. The end goal is to add the ability to run Pd-L2Ork patches in a web browser. Significant work has been done towards this goal, but there are still changes left to be made to add this functionality to Pd-L2Ork. The rest of this file is a guide for users (particularly those who aim to deploy their own WebPdL2Ork servers), as well as future developers on how to continue working on this project.
 
-## Build Guide
+# Build Guide
+
+WebPdL2Ork can be built in two ways: natively, and through docker. The docker build is much easier to set up, and is recommended for most use cases.
+
+## Docker Build
+
+1. Install docker and docker-compose (through whatever means are appropriate for your OS)
+
+2. Build the docker container from this repository:
+
+```bash
+cd <pd-l2ork-git-folder>
+docker-compose build
+```
+
+3. Run the docker container:
+
+```bash
+docker-compose up
+```
+
+Note that you can run the container in the background by using `docker-compose up -d`
+
+Configuration for the patch bind mount and port are in `docker-compose.yml`
+
+
+## Native Build
+
 1. Install emscripten SDK (requires git, instructions tested on Linux, please see https://emscripten.org/docs/getting_started/downloads.html#installation-instructions for instructions for other platforms). These instructions assume that you are ok installing emsdk in your ~/Downloads folder:
 
 		cd ~/Downloads
@@ -45,9 +72,17 @@ WebPdL2Ork is a Pd-L2Ork implementation and further development of the [PdWebPar
 		cd emscripten/projects/WebPdL2Ork
 		npm start
 
-6. For a default test patch, point your web browser to http://webpdl2ork-server-address:3000. For a specific patch hosted on the same server use http://webpdl2ork-server-address:3000?url=path-to-patch/patchname.pd (no path is necessary if you are referencing a patch in the docroot which should be in the emscripten/projects/WebPdL2Ork/public/ folder). You can also use the full address for the url parameter, e.g. http://webpdl2ork-server-address:3000?url=http://server-address-that-hosts-the-patch/path-to-patch/patchname.pd to point to a patch located on another server.
+# Usage
 
-## Future Work
+- For a default test patch, point your web browser to http://webpdl2ork-server-address:port/
+	- The port can be overriden using the PORT environment variable. It defaults to 3000.
+- For a specific patch hosted on the same server use http://webpdl2ork-server-address:port?url=path-to-patch/patchname.pd 
+	- The patch path is relative to the PATCH_PATH environment variable, which itself is relative to the location of index.js (the WebPdL2Ork folder), and defaults to "public". All patches in the public folder will be accessible no matter the value of PATCH_PATH, but PATCH_PATH can be set to another folder to make that folder accessible as well. 
+	- Note: In the docker build, PATH_PATH is set to public/patches, since in docker that is where the host public folder gets mounted to. However, this has no visible effect, as to add a patch from the host machine you still drop it into the public folder (unless you override the bind mount). For docker, it is recommended to override the bind mount instead of overriding PATCH_PATH.
+- For a patch hosted on another server use http://webpdl2ork-server-address:port?url=http://server-address-that-hosts-the-patch/path-to-patch/patchname.pd 
+
+# Future Work
+
 - Check for access to supporting files both locally and remotely.
 - Fix building of libraries that old version supported but the current one doesn't (see externals/Makefile).
 - After resolving the previous issues, if ther are stil problems, figure out what is preventing the support of more complex patches (e.g. Phase-Cancellation-Emscripten.pd).

--- a/emscripten/DOCUMENTATION.md
+++ b/emscripten/DOCUMENTATION.md
@@ -75,9 +75,9 @@ Configuration for the patch bind mount and port are in `docker-compose.yml`
 # Usage
 
 - For a default test patch, point your web browser to http://webpdl2ork-server-address:port/
-	- The port can be overriden using the PORT environment variable. It defaults to 3000.
+	- The port can be overriden using the PORT environment variable. It defaults to 3000. For example, use `PORT=80 npm run start` to run WebPdL2Ork on port 80 instead of port 3000.
 - For a specific patch hosted on the same server use http://webpdl2ork-server-address:port?url=path-to-patch/patchname.pd 
-	- The patch path is relative to the PATCH_PATH environment variable, which itself is relative to the location of index.js (the WebPdL2Ork folder), and defaults to "public". All patches in the public folder will be accessible no matter the value of PATCH_PATH, but PATCH_PATH can be set to another folder to make that folder accessible as well. 
+	- The patch path is relative to the PATCH_PATH environment variable, which itself is relative to the location of index.js (the WebPdL2Ork folder), and defaults to "public". All patches in the public folder will be accessible no matter the value of PATCH_PATH, but PATCH_PATH can be set to another folder to make that folder accessible as well. For example, use `PATCH_PATH=/path/to/patches npm run start` to tell WebPdL2Ork to look in `/path/to/patches` for patches.
 	- Note: In the docker build, PATH_PATH is set to public/patches, since in docker that is where the host public folder gets mounted to. However, this has no visible effect, as to add a patch from the host machine you still drop it into the public folder (unless you override the bind mount). For docker, it is recommended to override the bind mount instead of overriding PATCH_PATH.
 - For a patch hosted on another server use http://webpdl2ork-server-address:port?url=http://server-address-that-hosts-the-patch/path-to-patch/patchname.pd 
 

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -1398,7 +1398,7 @@ var Module = {
         var numInChannels = 0; // supported values: 0, 1, 2
         var numOutChannels = 2; // supported values: 1, 2
         var sampleRate = 44100; // might change depending on browser/system
-        var ticksPerBuffer = 32; // supported values: 4, 8, 16, 32, 64, 128, 256
+        var ticksPerBuffer = 64; // supported values: 4, 8, 16, 32, 64, 128, 256
 
         // open audio devices, init pd
         if (pd.init(numInChannels, numOutChannels, sampleRate, ticksPerBuffer)) {
@@ -2759,6 +2759,13 @@ function gui_atom_onmousedown(data, e, id) {
             }
             gui_atom_update(data);
         } else {
+            if(data.type !== 'floatatom') {
+                if(keyDown['Shift'])
+                    data.dirtyValue = data.value;
+                else
+                    data.dirtyValue = '';
+                gui_atom_settext(data, data.dirtyValue + (new Array(Math.max(0,3 - data.dirtyValue.length))).fill('.').join(''));
+            }
             setKeyboardFocus(data, data.exclusive);
             configure_item(data.svgText, {fill: '#ff0000'});
             if(data.type === 'floatatom') {
@@ -2808,6 +2815,15 @@ function gui_atom_keydown(data, e) {
     if(e.key === 'Enter') {
         gui_atom_commit(data);
         gui_atom_settext(data, '' + data.value);
+        
+        configure_item(data.svgText, {
+            'font-weight': 'bold',
+        });
+        setTimeout(() => {
+            configure_item(data.svgText, {
+                'font-weight': 'normal',
+            });
+        }, 100);
     }
 
     if(data.dirtyValue !== undefined)
@@ -4467,7 +4483,7 @@ async function openPatch(content, filename) {
                             inputListeners.push({
                                 onKeyDown: (e) => {
                                     if(e.repeat === false || data.repeat === true)
-                                        gui_send('Float',data.send, e.key.length == 1 ? e.key.charCodeAt(0) : 0);
+                                        gui_send('Float',data.send, e.key.length == 1 ? e.key.charCodeAt(0) : (e.keyCode == 27 ? 27 : 0));
                                 },
                                 priority: 5
                             })
@@ -4498,8 +4514,10 @@ async function openPatch(content, filename) {
                                     if(e.repeat === false || data.repeat === true) {
                                         if(e.key.match(/^F\d$/) && keyDown['Shift'])
                                             gui_send('Symbol', data.auxSend[0], "Shift"+e.key);
+                                        else if(e.key.match(/^Arrow/) && keyDown['Shift'])
+                                            gui_send('Symbol', data.auxSend[0], "Shift"+e.key.replace(/Arrow/, ''));
                                         else
-                                            gui_send('Symbol', data.auxSend[0], e.key);
+                                            gui_send('Symbol', data.auxSend[0], e.key.replace(/Backspace/, 'BackSpace').replace(/Arrow/,''));
                                         gui_send('Float', data.send, 1);
                                     }
                                 },
@@ -4507,8 +4525,10 @@ async function openPatch(content, filename) {
                                     if(e.repeat === false || data.repeat === true) {
                                         if(e.key.match(/^F\d$/) && keyDown['Shift'])
                                             gui_send('Symbol', data.auxSend[0], "Shift"+e.key);
+                                        else if(e.key.match(/^Arrow/) && keyDown['Shift'])
+                                            gui_send('Symbol', data.auxSend[0], "Shift"+e.key.replace(/Arrow/, ''));
                                         else
-                                            gui_send('Symbol', data.auxSend[0], e.key);
+                                            gui_send('Symbol', data.auxSend[0], e.key.replace(/Backspace/, 'BackSpace').replace(/Arrow/,''));
                                         gui_send('Float', data.send, 0);
                                     }
                                 }

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -5053,6 +5053,9 @@ async function openPatch(content, filename) {
                         //If the receiver is a gui object, and the sender is not, we must add a send object so that the receiver
                         //can receive wirelessly. Then we connect the send object to the sender, and the receiver wirelessly to the send object
                         if(layer.objects[args[2]] === 'preset_node') {
+                            // This is for preset nodes, it tricks them into thinking that they are physically connected to an object.
+                            // It creates a dummy canvas which is then connected to the preset node in the same way as the original
+                            // object, and also puts wireless sends and receives inside that canvas to interact with the GUI object.
                             lines.splice(i--, 1, 
                                 `#N canvas 0 0 0 0 ${connectionName} 1`,
                                 `#X obj 5 10 inlet`,

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -3311,6 +3311,7 @@ async function openPatch(content, filename) {
 
     document.getElementById('loadingstage').innerHTML=`Fetching Dependancies`;
     await new Promise(Resolve => setTimeout(Resolve, 10));
+    let start = Date.now();
     let abstractions = {};
     let fetchAbstractions = async(content, path) => {
         let missingAbstractions = [... new Set(content.split(';\n').filter( line => line.startsWith('#X obj') && !known_objects.includes(line.split(' ')[4]) ).map( line => line.split(' ')[4]))];
@@ -3328,9 +3329,10 @@ async function openPatch(content, filename) {
     await fetchAbstractions(content,'/');
 
     document.getElementById('loadingstage').innerHTML=`Parsing Patch`;
+    console.log('Fetch time: '+(Date.now() - start)+'ms');
     await new Promise(Resolve => setTimeout(Resolve, 10));
-
-    let start = Date.now();
+    
+    start = Date.now();
 
     document.removeEventListener('keydown', onKeyDown);
     document.removeEventListener('keyup', onKeyUp);

--- a/externals/Makefile
+++ b/externals/Makefile
@@ -517,13 +517,12 @@ CYCLONE_SHARED_SRC := \
 
 cyclone: $(CYCLONE_PATH)/bin/Hammer.wasm $(CYCLONE_PATH)/bin/Sickle.wasm
 
-$(externals_src)/miXed/cyclone/hammer/atodb.c.ignore: 
+$(CYCLONE_PATH)/bin/Hammer.wasm:
 	mv $(externals_src)/miXed/cyclone/hammer/atodb.c $(externals_src)/miXed/cyclone/hammer/atodb.c.ignore
-
-$(CYCLONE_PATH)/bin/Hammer.wasm: $(externals_src)/miXed/cyclone/hammer/atodb.c.ignore
 	touch $(externals_src)/miXed/cyclone/hammer/atodb.c
 	$(CC) $(CFLAGS) $(CYCLONE_FLAGS) -o $(CYCLONE_PATH)/bin/Hammer.wasm $(CYCLONE_SHARED_SRC) $(CYCLONE_HAMMER)
 	rm $(externals_src)/miXed/cyclone/hammer/atodb.c
+	mv $(externals_src)/miXed/cyclone/hammer/atodb.c.ignore $(externals_src)/miXed/cyclone/hammer/atodb.c
 
 $(CYCLONE_PATH)/bin/Sickle.wasm:
 	$(CC) $(CFLAGS) $(CYCLONE_FLAGS) -o $(CYCLONE_PATH)/bin/Sickle.wasm $(CYCLONE_SHARED_SRC) $(CYCLONE_SICKLE)


### PR DESCRIPTION
- Add PATCH_PATH environment variable to express server
- Update WebPdL2Ork documentation
- Update default docker config to not require patches/ prefix by default
- Clean up cyclone build process a bit
- Fixed various keyname inconsistancies with desktop (Shift+Arrow, Backspace, Escape)
- Fixed Symbol atoms not pulsing on enter
- Fixed Symbol atoms not showing three dots at proper time
- Increased default ticks per buffer to improve DSP performance
- Improved documentation of preset_node workaround