### PR TITLE
Bugfixes and Improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   webpdl2ork:
     build: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     build: 
       context: .
       dockerfile: webpdl2ork.Dockerfile
-    #ports:
-    #  - "3000:80" # Serve without proxy
+    ports:
+      - "3000:80" # Serve without proxy
     environment:
       - PORT=80
       - PATCH_PATH=public/patches
@@ -16,8 +16,8 @@ services:
     container_name: webpdl2ork
   nginx:
     image: nginxproxy/nginx-proxy:alpine
-    ports:
-      - "3000:443" # Serve using https (requires certificates)
+    #ports:
+    #  - "3000:443" # Serve using https (requires certificates)
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs

--- a/emscripten/DOCUMENTATION.md
+++ b/emscripten/DOCUMENTATION.md
@@ -89,9 +89,14 @@ By default WebPdL2Ork is served over http. To enable https support (required for
 
 1. Build the webpdl2ork docker container, using the instructions above.
 2. Comment the `ports: ` line and the `- "3000:80"` line in the webpdl2ork container in `docker-compose.yml`
-3. Uncomment the two commented lines in the nginx-proxy container in `docker-compose.yml`. If you want to expose pd-l2ork on another port other than 3000, you can change the line that has `3000` to reflect that.
+3. Uncomment the two commented lines in the nginx-proxy container in `docker-compose.yml`. If you want to expose pd-l2ork on another port other than 3000, you can change the line that has `3000` to reflect that. Be careful with indentation, make sure that they are indented in the same was as the other configuration options in this section.
 4. Set the `VIRTUAL_HOST` environment variable for the webpdl2ork container to match the domain name you are using.
 5. Place your certiciates in the `certs` directory in the root folder of this repository. The certificates should be named as `my.domain.name.crt` and `my.domain.name.key`, assuming that the server is available under `my.domain.name`.
+	- If your certificates are in pem format, you can convert them using the following commands:
+	```bash
+	openssl x509 -in your-cert.pem -out my.domain.name.crt
+	openssl pkey -in your-privkey.pem -out my.domain.name.key
+	```
 
 # Future Work
 

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -3101,8 +3101,8 @@ let keyDown = {}
 function onKeyDown(e) {
     if(keyboardFocus.data?.onKeyDown)
         keyboardFocus.data.onKeyDown(keyboardFocus.data, e);
+    keyDown[e.key] = true;
     if(keyboardFocus.exclusive == false) {
-        keyDown[e.key] = true;
         for(let listener of inputListeners.sort((a,b) => (b.priority || 0) - (a.priority || 0))) {
             if(listener.onKeyUp && e.repeat)
                 listener.onKeyUp(e);

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -3099,6 +3099,7 @@ let keyboardFocus = { data: null, exclusive: false, current: false};
 let inputListeners = [];
 let keyDown = {}
 function onKeyDown(e) {
+    e.preventDefault();
     if(keyboardFocus.data?.onKeyDown)
         keyboardFocus.data.onKeyDown(keyboardFocus.data, e);
     keyDown[e.key] = true;
@@ -3112,6 +3113,7 @@ function onKeyDown(e) {
     }
 }
 function onKeyUp(e) {
+    e.preventDefault();
     if(keyboardFocus.data?.onKeyUp)
         keyboardFocus.data.onKeyUp(keyboardFocus.data, e);
     keyDown[e.key] = false;
@@ -4559,7 +4561,7 @@ async function openPatch(content, filename) {
                             inputListeners.push({
                                 onKeyDown: e => {
                                     if(e.repeat === false || data.repeat === true) {
-                                        if(e.key.match(/^F\d$/) && keyDown['Shift'])
+                                        if(e.key.match(/^F\d+$/) && keyDown['Shift'])
                                             gui_send('Symbol', data.auxSend[0], "Shift"+e.key);
                                         else if(e.key.match(/^Arrow/) && keyDown['Shift'])
                                             gui_send('Symbol', data.auxSend[0], "Shift"+e.key.replace(/Arrow/, ''));
@@ -4570,7 +4572,7 @@ async function openPatch(content, filename) {
                                 },
                                 onKeyUp: e => {
                                     if(e.repeat === false || data.repeat === true) {
-                                        if(e.key.match(/^F\d$/) && keyDown['Shift'])
+                                        if(e.key.match(/^F\d+$/) && keyDown['Shift'])
                                             gui_send('Symbol', data.auxSend[0], "Shift"+e.key);
                                         else if(e.key.match(/^Arrow/) && keyDown['Shift'])
                                             gui_send('Symbol', data.auxSend[0], "Shift"+e.key.replace(/Arrow/, ''));

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -116,8 +116,10 @@ async function pasteTextFromClipboard() {
             console.error("Failed to paste text: ", err);
             return "";
         });
-    } else
-        console.error("Paste is not available on an http connection");
+    } else {
+        alert("Paste is only available over a secure connection");
+        return "";
+    }
 }
 
 function copyTextToClipboard(text) {
@@ -2851,6 +2853,12 @@ function gui_atom_keydown(data, e) {
     }
     if(e.key === 'c' && (keyDown['Control'] || keyDown['Meta'])) {
         copyTextToClipboard(data.dirtyValue);
+        return;
+    }
+    if(e.key === 'x' && (keyDown['Control'] || keyDown['Meta'])) {
+        copyTextToClipboard(data.dirtyValue);
+        data.dirtyValue = '';
+        gui_atom_settext(data, data.dirtyValue + (new Array(Math.max(0,3 - data.dirtyValue.length))).fill('.').join(''));
         return;
     }
 

--- a/externals/Makefile
+++ b/externals/Makefile
@@ -160,7 +160,7 @@ lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc
 # short one for quick building for debugging purposes (disabled by default):
 # lib_targets = maxlib
 else
-lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui fluid freeverb ggee hcs iem_ambi iem_bin_ambi iemlib iemgui iemguts iem_adaptfilt iemmatrix iemxmlrpc iem_delay iem_roomsim iem_spec2 iem_tab jasch_lib loaders-libdir lyonpotpourri mapping markex maxlib mjlib moocow moonlib motex mrpeach oscx pan pdcontainer pddp pdlua pdogg plugin pmpd rjlib sigpack smlib tof unauthorized vbap windowing zexy
+lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui fluid freeverb ggee hcs iem_ambi iem_bin_ambi iemlib iemgui iemguts iem_adaptfilt iemmatrix iemxmlrpc iem_delay iem_roomsim iem_spec2 iem_tab jasch_lib js loaders-libdir lyonpotpourri mapping markex maxlib mjlib moocow moonlib motex mrpeach oscx pan pdcontainer pddp pdlua pdogg plugin pmpd rjlib sigpack smlib tof unauthorized vbap windowing zexy
 endif
 
 
@@ -1644,7 +1644,7 @@ pddp_clean:
 #------------------------------------------------------------------------------#
 # pdjs
 
-pdjs:
+js:
 ifeq ($(OS_NAME),windows)
 	cd $(externals_src)/pdjs-win/v8 && unzip -u lib.zip
 	cd $(externals_src)/pdjs-win \
@@ -1675,7 +1675,7 @@ else
 endif
 endif
 
-pdjs_install:
+js_install:
 	install -d $(DESTDIR)$(objectsdir)/js
 ifeq ($(OS_NAME),windows)
 	install -p $(externals_src)/pdjs-win/binaries/x86-windows/js.$(EXTENSION) \
@@ -1711,7 +1711,7 @@ else
 endif
 endif
 
-pdjs_clean:
+js_clean:
 ifeq ($(OS_NAME),windows)
 	cd $(externals_src)/pdjs-win \
 		&& /mingw32/bin/cmake --build out/build/x86-mingw-Debug --target clean

--- a/externals/Makefile
+++ b/externals/Makefile
@@ -160,13 +160,7 @@ lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc
 # short one for quick building for debugging purposes (disabled by default):
 # lib_targets = maxlib
 else
-lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui fluid freeverb ggee hcs iem_ambi iem_bin_ambi iemlib iemgui iemguts iem_adaptfilt iemmatrix iemxmlrpc iem_delay iem_roomsim iem_spec2 iem_tab jasch_lib loaders-libdir lyonpotpourri mapping markex maxlib mjlib moocow moonlib motex mrpeach oscx pan pdcontainer pddp pdogg plugin pmpd rjlib sigpack smlib tof unauthorized vbap windowing zexy
-ifneq ($(OS_NAME),darwin)
-ifneq ($(shell uname -m),arm64)
-# pdlua crashes the arm build of pd-l2ork on arm based macbooks, so we don't include it in that case
-lib_targets += pdlua
-endif 
-endif
+lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui fluid freeverb ggee hcs iem_ambi iem_bin_ambi iemlib iemgui iemguts iem_adaptfilt iemmatrix iemxmlrpc iem_delay iem_roomsim iem_spec2 iem_tab jasch_lib loaders-libdir lyonpotpourri mapping markex maxlib mjlib moocow moonlib motex mrpeach oscx pan pdcontainer pddp pdlua pdogg plugin pmpd rjlib sigpack smlib tof unauthorized vbap windowing zexy
 endif
 
 

--- a/packages/darwin_app/Makefile
+++ b/packages/darwin_app/Makefile
@@ -215,6 +215,7 @@ dmg:
 # ico@vt.edu 2022-10-10: sign the app, so that we can get the mic/camera
 # permission prompts
 	codesign --deep --sign "-" --entitlements "$(CWD)/pd-l2ork.entitlements" "$(BUILD_BASE)/Pd-L2Ork.app"
+	./sign-MacOSX-dependencies.sh $(PD_APP_CONTENTS)
 	rm -f build.dmg
 	hdiutil create -format UDRW -fs HFS+ -srcfolder "$(BUILD_BASE)" \
 		-volname $(VOLUME_NAME) build.dmg

--- a/packages/darwin_app/sign-MacOSX-dependencies.sh
+++ b/packages/darwin_app/sign-MacOSX-dependencies.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# This script finds all of the dependecies from Homebrew or MacPorts and
+# resigns them (this is meant to be run after embed-MacOSX-dependencies.sh)
+#
+# run it in the root directory where the externals are stored, i.e. "extra"
+
+    
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 Pd.app-Contents"
+	echo "  i.e. $0 /Applications/Pd.app/Contents/"
+	exit
+fi
+
+# Check whether we have Homebrew or MacPorts, prefer the former.
+optlocal=$((test -n "$HOMEBREW_PREFIX" && test -d $HOMEBREW_PREFIX/opt && echo $HOMEBREW_PREFIX/opt) || (test -d /opt/local && echo /opt/local) || echo /usr/local)
+# Determine the actual installation prefix. On Homebrew, this is
+# $HOMEBREW_PREFIX, otherwise (MP or none) it's just $optlocal.
+if test -n "$HOMEBREW_PREFIX" && test -d $HOMEBREW_PREFIX; then
+    usrlocal=$HOMEBREW_PREFIX
+else
+    usrlocal=$optlocal
+fi
+
+LIB_DIR=lib
+PD_APP_CONTENTS=$1
+PD_APP_LIB=$PD_APP_CONTENTS/$LIB_DIR
+PD_APP_PLUGINS=$PD_APP_CONTENTS/Plugins
+
+#echo "PD_APP_CONTENTS: $PD_APP_CONTENTS"
+#echo "PD_APP_LIB: $PD_APP_LIB"
+
+echo " "
+
+for pd_darwin in `find $PD_APP_CONTENTS -name '*.pd_darwin'`; do
+    codesign --force -s - $pd_darwin
+done
+
+# check for .so plugins used by libquicktime and others
+for so in $PD_APP_PLUGINS/*/*.so; do
+    codesign --force -s - $so
+done
+
+if test -d $PD_APP_LIB; then
+
+for dylib in $PD_APP_LIB/*.dylib; do
+    codesign --force -s - $dylib
+done
+
+fi

--- a/pd/nw/pd_canvas.js
+++ b/pd/nw/pd_canvas.js
@@ -1886,11 +1886,36 @@ var canvas_events = (function() {
 
             // Cut event
             document.addEventListener("cut", function(evt) {
-                // This event doesn't currently get called because the
-                // nw menubar receives the event and doesn't propagate
-                // to the DOM. But if we add the ability to toggle menubar
-                // display, we might need to rely on this listener.
-                pdgui.pdsend(name, "cut");
+                // On OSX, this event gets triggered when we're editing
+                // inside an object/message box, including activated objects.
+                // ico@vt.edu 2021-10-20: we don't need the search part since
+                // that one for some reason works just fine on OSX (see
+                // m.edit.copy above)
+                if (pdgui.gui_is_gobj_grabbed(name)) {
+                    // ico@vt.edu 2021-10-08: cutting contents of a grabbed object
+                    //pdgui.post("gobj_grabbed copy");
+                    var clipboard = nw.Clipboard.get();
+                    var activated_gobj =
+                        document.getElementsByClassName("activated");
+                    // currently we only support cutting from gatoms and number2
+                    // gatoms will belong to the class atom, while number2 will have
+                    // parent object that will belong to the class iemgui
+                    if (activated_gobj[0].classList.contains("atom"))
+                        clipboard.set(activated_gobj[0].textContent, 'text');
+                    else if (activated_gobj[0].parentNode.classList.contains("iemgui")) {
+                        var output = activated_gobj[0].textContent.replace('>', '');
+                        clipboard.set(output, 'text');
+                    }
+                    for (var i = 0; i < clipboard.get('text').length; i++) {
+                        // Send backspace
+                        pdgui.canvas_sendkey(name, 1, 0, 8, 0);
+                        pdgui.canvas_sendkey(name, 0, 0, 8, 0);
+                    }
+                } else if (canvas_events.get_state() === "normal") {
+                    // So, we only forward the copy message to Pd if we're in a
+                    // "normal" canvas state
+                    pdgui.pdsend(name, "cut");
+                }
             });
 
             // Copy event
@@ -2816,6 +2841,28 @@ function nw_create_patch_window_menus(gui, name) {
                 if (document.getSelection()) {
                     document.execCommand("cut");
                 }
+            } else if (pdgui.gui_is_gobj_grabbed(name)) {
+                // ico@vt.edu 2021-10-08: copying contents of a grabbed object
+                //pdgui.post("gobj_grabbed copy");
+                var clipboard = nw.Clipboard.get();
+                var activated_gobj =
+                    document.getElementsByClassName("activated");
+                // currently we only support copying from gatoms and number2
+                // gatoms will belong to the class atom, while number2 will have
+                // parent object that will belong to the class iemgui
+                if (activated_gobj[0].classList.contains("atom"))
+                    clipboard.set(activated_gobj[0].textContent, 'text');
+                else if (activated_gobj[0].parentNode.classList.contains("iemgui")) {
+                    var output = activated_gobj[0].textContent.replace('>', '');
+                    clipboard.set(output, 'text');
+                }
+                for (var i = 0; i < clipboard.get('text').length; i++) {
+                    // Backspace
+                    pdgui.canvas_sendkey(name, 1, 0, 8, 0);
+                    pdgui.canvas_sendkey(name, 0, 0, 8, 0);
+                }
+            } else {
+                pdgui.pdsend(name, "cut");
             }
         }
     });


### PR DESCRIPTION
Docker-compose fixes, copypaste emscripten, cut, pdlua macos, keyname issues emscripten

- Fixed default docker-compose for WebPdL2Ork
- Improved documentation for HTTPS support on WebPdL2Ork
- Fixed Copy/Paste on exclusive atoms on WebPdL2Ork
- Added Cut support for atoms on desktop PdL2Ork
- Added Cut support for atoms on WebPdL2Ork
- Fixed pdlua for ARM builds on macos
- Fixed keyname errors on WebPdL2ork (namely Shift+F10-F12)