### PR TITLE
PdWebParty Hotfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ CVS
 .DS_Store
 *.dmg
 .vscode/
+logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     build: 
       context: .
       dockerfile: webpdl2ork.Dockerfile
-    ports:
-      - "3000:80" # Serve without proxy
+    #ports:
+    #  - "3000:80" # Serve without proxy
     environment:
       - PORT=80
       - PATCH_PATH=public/patches
@@ -16,8 +16,8 @@ services:
     container_name: webpdl2ork
   nginx:
     image: nginxproxy/nginx-proxy:alpine
-    #ports:
-    #  - "3000:443" # Serve using https (requires certificates)
+    ports:
+      - "3000:443" # Serve using https (requires certificates)
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,6 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs
+      - ./logs:/var/log/nginx
     restart: unless-stopped
     container_name: nginx-proxy

--- a/emscripten/projects/WebPdL2Ork/package.json
+++ b/emscripten/projects/WebPdL2Ork/package.json
@@ -10,8 +10,8 @@
   "author": "Zack Lee",
   "license": "GPLV3",
   "dependencies": {
+    "axios": "^1.7.2",
     "body-parser": "^1.19.0",
-    "dependencies": "^0.0.1",
     "express": "^4.17.1"
   }
 }

--- a/webpdl2ork.Dockerfile
+++ b/webpdl2ork.Dockerfile
@@ -1,7 +1,7 @@
 # Build pd-l2ork using emsdk
 FROM emscripten/emsdk AS builder
 WORKDIR /pd-l2ork/
-RUN apt-get update && apt-get upgrade -y && apt-get install -y autoconf
+RUN apt-get update && apt-get upgrade -y && apt-get install -y autoconf pkgconf
 COPY . .
 RUN cd emscripten; make clean; make
 


### PR DESCRIPTION
- Added docker mount for nginx logs
- Fix virtual local loading of remote files

Re this patch: https://l2ork.music.vt.edu:3000/?url=https://msp.ucsd.edu/tmp/manoury-pluton/pluton.pd
Fixed all the 404 errors, now the only errors are from missing externals (which I couldnt find on that site? will investigate more soon, but the issue with virtual local loading is a relatively major issue, so I wanted to make sure it gets patched, as it will break a lot more patches than the potential externals issue).

I also streamlined the patch loading and file loading process so now it can batch load (for example, tweeter now fetches network data about 4x faster, using only 14 web requests instead of ~150 to fetch abstractions. For file loading, where these requests have to be executed in series, not parallel, this has the potential to greatly increase loading speed. Also, this will lighten the burden on the server, only having to serve ~10% of the requests as it would otherwise have had to serve.