### PR TITLE
WebPdL2Ork Bugfixes (Last batch for now)

### DIFF
--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -3168,11 +3168,16 @@ function setKeyboardFocus(data, exclusive) {
     }
     if(keyboardFocus?.data?.onLoseFocus)
         keyboardFocus.data.onLoseFocus(keyboardFocus.data);
+    if(data !== null)
+        document.getElementById('keyboardTrigger').focus();
+    else
+        document.getElementById('keyboardTrigger').blur();
     keyboardFocus.data = data;
     keyboardFocus.exclusive = exclusive;
     keyboardFocus.current = true;
 }
 function onMouseDown(e) {
+    e.preventDefault?.();
     if(keyboardFocus.current == false)
         setKeyboardFocus(null, false);
     keyboardFocus.current = false;
@@ -3182,6 +3187,7 @@ function onMouseDown(e) {
             listener.onMouseDown(e);
 }
 function onMouseUp(e) {
+    e.preventDefault?.();
     for(let listener of inputListeners)
         if(listener.onMouseUp)
             listener.onMouseUp(e);
@@ -4530,7 +4536,7 @@ async function openPatch(content, filename) {
                                 data.canvas = layer.canvas;
 
                                 let nextObjId = layer.nextGUIID, nextSlot = i, depth = 0;
-                                for(;lines[nextSlot].startsWith('#X connect') == false || depth > 0; nextSlot++) {
+                                for(;(lines[nextSlot] && lines[nextSlot].startsWith('#X connect') == false && lines[nextSlot].startsWith('#X restore') == false) || depth > 0; nextSlot++) {
                                     if(object_types.find(type=>lines[nextSlot].startsWith(type)) && depth == 0)
                                         nextObjId++;
                                     if(lines[nextSlot].startsWith('#N canvas'))
@@ -4840,7 +4846,7 @@ async function openPatch(content, filename) {
                     layer.messages.push(data);
 
                     let nextObjId = layer.nextGUIID, nextSlot = i, depth = 0;
-                    for(;lines[nextSlot].startsWith('#X connect') == false || depth > 0; nextSlot++) {
+                    for(;(lines[nextSlot] && lines[nextSlot].startsWith('#X connect') == false && lines[nextSlot].startsWith('#X restore') == false) || depth > 0; nextSlot++) {
                         if(object_types.find(type=>lines[nextSlot].startsWith(type)) && depth == 0)
                             nextObjId++;
                         if(lines[nextSlot].startsWith('#N canvas'))

--- a/emscripten/projects/WebPdL2Ork/views/index.html
+++ b/emscripten/projects/WebPdL2Ork/views/index.html
@@ -29,6 +29,7 @@
 	<div id="filter"></div>
 	<script src="js/main.js"></script>
 	<script src="emscripten/main.js"></script>
+	<input style="position: absolute; opacity: 0" id="keyboardTrigger"/>
 </body>
 
 </html>

--- a/pd/src/x_connective.c
+++ b/pd/src/x_connective.c
@@ -258,16 +258,28 @@ static void bang_bang(t_bang *x)
     outlet_bang(x->x_obj.ob_outlet);
 }
 
+static void bang_float(t_bang *x, t_float f) {
+    outlet_bang(x->x_obj.ob_outlet);
+}
+
+static void bang_symbol(t_bang *x, t_symbol *s) {
+    outlet_bang(x->x_obj.ob_outlet);
+}
+
+static void bang_list(t_bang *x, t_symbol *s, int argc, t_atom *argv) {
+    outlet_bang(x->x_obj.ob_outlet);
+}
+
 void bang_setup(void)
 {
     bang_class = class_new(gensym("bang"), (t_newmethod)bang_new, 0,
         sizeof(t_bang), 0, 0);
     class_addcreator((t_newmethod)bang_new2, gensym("b"), 0);
     class_addbang(bang_class, bang_bang);
-    class_addfloat(bang_class, bang_bang);
-    class_addsymbol(bang_class, bang_bang);
-    class_addlist(bang_class, bang_bang);
-    class_addanything(bang_class, bang_bang);
+    class_addfloat(bang_class, bang_float);
+    class_addsymbol(bang_class, bang_symbol);
+    class_addlist(bang_class, bang_list);
+    class_addanything(bang_class, bang_list);
 }
 
 /* -------------------- send ------------------------------ */


### PR DESCRIPTION
- Fixes mismatched function error in pluton on WebPdL2Ork
- Fixes connection errors in pluton in WebPdL2Ork
- Shows touch keyboard on mobile devices when focusing atom or nbx on WebPdL2Ork


This should be all the remaining issues with WebPdL2Ork that are currently known.

The errors popping up about "unknown object" *seem* to be not an issue, I hooked up a print to one of those and sending messages to it works, and the loadbang happens *after* all of the errors. So, pending a functionality issue coming up (which won't be able to investigate until the externals are gotten for that patch) I don't think its an issue.


You don't want to know how long it took to figure out that the bang object was the one that was broken just to change about 10 lines in its source... I am considering investigating a way to find issues like that at compile time and block compilation if there are any mismatched functions.