### PR TITLE
WebPdL2Ork

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
 docker-compose.yml
 *.Dockerfile
+emscripten/projects/WebPdL2Ork/public/*
+!emscripten/projects/WebPdL2Ork/public/js
+!emscripten/projects/WebPdL2Ork/public/emscripten
+!emscripten/projects/WebPdL2Ork/public/css
+!emscripten/projects/WebPdL2Ork/public/default.pd
+!emscripten/projects/WebPdL2Ork/public/favicon.ico

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -25,7 +25,7 @@ ifeq ($(DEBUG), true)
     EM_FLAGS = -s SIDE_MODULE=1 -g
     TYPE = Debug
 endif
-CFLAGS = -DPD -I$(PD_PATH)/src $(WARN_FLAGS) $(EM_FLAGS)
+CFLAGS = -DPD -I$(PD_PATH)/src -D__linux__ $(WARN_FLAGS) $(EM_FLAGS)
 LDFLAGS = $(EM_FLAGS)
 LIBS = 
 CC = emcc
@@ -49,9 +49,9 @@ libpd: $(LIBPD_PATH)
 
 
 externals: $(PD_L2ORK_DIR)/externals
-	make -C $< EMSCRIPTEN="yes" WARN_FLAGS="$(WARN_FLAGS)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" LIBS="$(LIBS)" CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" EXTENSION="$(EXTENSION)" STRIP="$(STRIP)"
+	make -C $< -j`nproc` EMSCRIPTEN="yes" WARN_FLAGS="$(WARN_FLAGS)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" LIBS="$(LIBS)" CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" EXTENSION="$(EXTENSION)" STRIP="$(STRIP)"
 	mkdir -p $(DESTDIR)/$(objectsdir)
-	make -C $< EMSCRIPTEN="yes" DESTDIR="$(DESTDIR)" EXTENSION="$(EXTENSION)" STRIP="$(STRIP)" objectsdir="$(objectsdir)" install
+	make -C $< -j`nproc` EMSCRIPTEN="yes" DESTDIR="$(DESTDIR)" EXTENSION="$(EXTENSION)" STRIP="$(STRIP)" objectsdir="$(objectsdir)" install
 
 extras = bob~ bonk~ choice fiddle~ loop~ lrshift~ pique sigmund~ stdout
 extra: $(extras)

--- a/emscripten/build/Makefile
+++ b/emscripten/build/Makefile
@@ -24,7 +24,7 @@ OUTPUT_FILES = $(TARGET) main.js main.wasm main.data
 CFLAGS = -I$(PD_PATH)/src -I$(LIBPD_PATH)/libpd_wrapper -O3 -fsanitize=address
 LDFLAGS = -L$(LIBPD_PATH)/libs -lpd -lm -sENVIRONMENT=web -sSTACK_SIZE=1048576
 ifeq ($(DEBUG), true)
-    CFLAGS = -I$(PD_PATH)/src -I$(LIBPD_PATH)/libpd_wrapper -g -O0 -fsanitize=address
+    CFLAGS = -I$(PD_PATH)/src -I$(LIBPD_PATH)/libpd_wrapper -gsource-map -O0 -fsanitize=address
     LDFLAGS += -sASSERTIONS=2 -sEXCEPTION_DEBUG -sSTACK_OVERFLOW_CHECK=1 --profiling-funcs
 endif
 

--- a/emscripten/projects/WebPdL2Ork/package.json
+++ b/emscripten/projects/WebPdL2Ork/package.json
@@ -5,13 +5,14 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "dev": "DISABLE_CACHE=1 node index.js"
   },
   "author": "Zack Lee",
   "license": "GPLV3",
   "dependencies": {
     "axios": "^1.7.2",
-    "body-parser": "^1.19.0",
+    "compression": "^1.7.4",
     "express": "^4.17.1"
   }
 }

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -3168,11 +3168,16 @@ function setKeyboardFocus(data, exclusive) {
     }
     if(keyboardFocus?.data?.onLoseFocus)
         keyboardFocus.data.onLoseFocus(keyboardFocus.data);
+    if(data !== null)
+        document.getElementById('keyboardTrigger').focus();
+    else
+        document.getElementById('keyboardTrigger').blur();
     keyboardFocus.data = data;
     keyboardFocus.exclusive = exclusive;
     keyboardFocus.current = true;
 }
 function onMouseDown(e) {
+    e.preventDefault?.();
     if(keyboardFocus.current == false)
         setKeyboardFocus(null, false);
     keyboardFocus.current = false;
@@ -3182,6 +3187,7 @@ function onMouseDown(e) {
             listener.onMouseDown(e);
 }
 function onMouseUp(e) {
+    e.preventDefault?.();
     for(let listener of inputListeners)
         if(listener.onMouseUp)
             listener.onMouseUp(e);
@@ -4530,7 +4536,7 @@ async function openPatch(content, filename) {
                                 data.canvas = layer.canvas;
 
                                 let nextObjId = layer.nextGUIID, nextSlot = i, depth = 0;
-                                for(;lines[nextSlot].startsWith('#X connect') == false || depth > 0; nextSlot++) {
+                                for(;(lines[nextSlot] && lines[nextSlot].startsWith('#X connect') == false && lines[nextSlot].startsWith('#X restore') == false) || depth > 0; nextSlot++) {
                                     if(object_types.find(type=>lines[nextSlot].startsWith(type)) && depth == 0)
                                         nextObjId++;
                                     if(lines[nextSlot].startsWith('#N canvas'))
@@ -4840,7 +4846,7 @@ async function openPatch(content, filename) {
                     layer.messages.push(data);
 
                     let nextObjId = layer.nextGUIID, nextSlot = i, depth = 0;
-                    for(;lines[nextSlot].startsWith('#X connect') == false || depth > 0; nextSlot++) {
+                    for(;(lines[nextSlot] && lines[nextSlot].startsWith('#X connect') == false && lines[nextSlot].startsWith('#X restore') == false) || depth > 0; nextSlot++) {
                         if(object_types.find(type=>lines[nextSlot].startsWith(type)) && depth == 0)
                             nextObjId++;
                         if(lines[nextSlot].startsWith('#N canvas'))

--- a/emscripten/projects/WebPdL2Ork/views/index.html
+++ b/emscripten/projects/WebPdL2Ork/views/index.html
@@ -18,6 +18,7 @@
 </head>
 
 <body>
+	<input style="position: absolute; top: 0; opacity: 0" id="keyboardTrigger"/>
 	<svg id="canvas" width="100%" height="100%" viewBox="0 0 450 300" preserveAspectRatio="xMidYMin meet"></svg>
 	<div id="loading">
 		<h2>Starting WebPdL2Ork</h2>
@@ -29,7 +30,6 @@
 	<div id="filter"></div>
 	<script src="js/main.js"></script>
 	<script src="emscripten/main.js"></script>
-	<input style="position: absolute; opacity: 0" id="keyboardTrigger"/>
 </body>
 
 </html>

--- a/emscripten/projects/WebPdL2Ork/views/index.html
+++ b/emscripten/projects/WebPdL2Ork/views/index.html
@@ -29,6 +29,7 @@
 	<div id="filter"></div>
 	<script src="js/main.js"></script>
 	<script src="emscripten/main.js"></script>
+	<input style="position: absolute; opacity: 0" id="keyboardTrigger"/>
 </body>
 
 </html>

--- a/externals/Makefile
+++ b/externals/Makefile
@@ -154,15 +154,17 @@ ifeq ($(LIGHT),yes)
 # minimal set of extensions for the "light" build
 lib_targets = loaders-libdir pddp
 INCREMENTAL = yes
-else ifeq ($(EMSCRIPTEN),yes)
-# original one used by the first iteration of WebPdL2Ork: lib_targets = arraysize autotune bassemu boids bsaylor comport creb cxc earplug ekext ext13 freeverb ggee hcs iem_ambi iem_bin_ambi iemguts iem_adaptfilt iem_delay iem_roomsim iem_spec2 jasch_lib loaders-libdir mapping markex maxlib mjlib moonlib motex mrpeach pan pddp rjlib plugin pmpd sigpack smlib tof unauthorized vbap windowing
-lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui fluid flatspace freeverb ggee hcs iemlib iemgui iemguts jasch_lib loaders-libdir lyonpotpourri mapping markex maxlib mjlib moonlib motex mrpeach oscx pan pdcontainer pddp pdogg rjlib plugin pmpd sigpack smlib tof unauthorized vbap windowing zexy
-# short one for quick building for debugging purposes (disabled by default):
-# lib_targets = maxlib
 else
-lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui fluid freeverb ggee hcs iem_ambi iem_bin_ambi iemlib iemgui iemguts iem_adaptfilt iemmatrix iemxmlrpc iem_delay iem_roomsim iem_spec2 iem_tab jasch_lib js loaders-libdir lyonpotpourri mapping markex maxlib mjlib moocow moonlib motex mrpeach oscx pan pdcontainer pddp pdlua pdogg plugin pmpd rjlib sigpack smlib tof unauthorized vbap windowing zexy
+lib_targets = adaptive arraysize autotune bassemu boids bsaylor comport creb cxc cyclone disis earplug ekext ext13 fftease flatgui fluid freeverb ggee hcs iem_ambi iem_bin_ambi iemlib iemgui iemguts iem_adaptfilt iemmatrix iemxmlrpc iem_delay iem_roomsim iem_spec2 iem_tab jasch_lib loaders-libdir lyonpotpourri mapping markex maxlib mjlib moocow moonlib motex mrpeach oscx pan pdcontainer pddp pdogg plugin pmpd rjlib sigpack smlib tof unauthorized vbap windowing zexy
 endif
 
+# Emscriptem needs flatspace for some objects, wheras normal PD has them builtin
+# Additionally, the pdjs and pdlua externals are currently not supported in emscripten.
+ifeq ($(EMSCRIPTEN),yes)
+lib_targets += flatspace
+else
+lib_targets += js pdlua
+endif
 
 # NEW (IN-PROGRESS): flext
 
@@ -504,7 +506,7 @@ cyclone_clean:
 		clean
 else
 CYCLONE_NAME := cyclone
-CYCLONE_FLAGS := -s -I${CYCLONE_PATH}/cyclone -I$(pd_src)/../libpd/libpd_wrapper -I$(externals_src)/miXed/shared -D__linux__ -DUNIX -fPIC
+CYCLONE_FLAGS := -s -I${CYCLONE_PATH}/cyclone -I$(pd_src)/../libpd/libpd_wrapper -I$(externals_src)/miXed/shared -DUNIX -fPIC
 CYCLONE_PATH := $(externals_src)/miXed/
 CYCLONE_HAMMER := $(wildcard $(externals_src)/miXed/cyclone/hammer/*.c)
 CYCLONE_SICKLE := $(wildcard $(externals_src)/miXed/cyclone/sickle/*.c)
@@ -1068,11 +1070,6 @@ hidin_clean:
 
 #------------------------------------------------------------------------------#
 # General IEM flags
-ifeq ($(EMSCRIPTEN),yes)
-IEM_FLAGS=-D__linux__ -Wno-incompatible-pointer-types
-else
-IEM_FLAGS=-O2
-endif
 
 #------------------------------------------------------------------------------#
 # IEM_AMBI
@@ -1190,14 +1187,6 @@ IEMGUTS_NAME=iemguts
 IEMGUTS_OBJECTS := $(wildcard $(externals_src)/iem/iemguts/src/*.c)
 iemguts: $(IEMGUTS_OBJECTS:.c=.$(EXTENSION))
 
-ifeq ($(EMSCRIPTEN),yes)
-$(IEMGUTS_OBJECTS:.c=.o) : $(IEMGUTS_OBJECTS)
-	$(CC) $(CFLAGS) $(IEM_FLAGS) -funroll-loops -fomit-frame-pointer -fno-tree-vectorize -fno-strict-aliasing -o "$*.o" -c "$*.c"
-
-$(IEMGUTS_OBJECTS:.c=.$(EXTENSION)) : $(IEMGUTS_OBJECTS:.c=.o)
-	$(CC) $(LDFLAGS) $(IEM_FLAGS) -o "$*.${EXTENSION}" "$*.o"
-endif
-
 iemguts_install: iemguts
 	install -d $(DESTDIR)$(objectsdir)/$(IEMGUTS_NAME)
 	$(scripts_src)/generate-libdir-metafile.sh $(DESTDIR)$(objectsdir) $(IEMGUTS_NAME) \
@@ -1230,7 +1219,7 @@ IEMLIB_SRC := $(wildcard $(externals_src)/iemlib/iemlib1/src/*[^1].c) $(wildcard
 
 IEMLIB_OBJECTS := $(IEMLIB_SRC:.c=.o)
 $(IEMLIB_OBJECTS) : %.o : %.c
-	$(CC) -I$(externals_src)/iemlib/include $(CFLAGS) $(IEM_FLAGS) -funroll-loops -fomit-frame-pointer -fno-tree-vectorize -fno-strict-aliasing -o "$*.o" -c "$*.c"
+	$(CC) -I$(externals_src)/iemlib/include $(CFLAGS) -O2 -funroll-loops -fomit-frame-pointer -fno-tree-vectorize -fno-strict-aliasing -o "$*.o" -c "$*.c"
 
 iemlib: $(IEMLIB_SRC:.c=.$(EXTENSION))
 
@@ -2296,7 +2285,7 @@ ZEXY_NAME = zexy
 ZEXY_SRC := $(wildcard $(externals_src)/zexy/src/*.c)
 ZEXY_OBJECTS := $(ZEXY_SRC:.c=.o)
 ZEXY_TARGETS := $(ZEXY_SRC:.c=.$(EXTENSION))
-ZEXY_FLAGS := 
+ZEXY_FLAGS := -DZ_WANT_LPT=0
 
 zexy: $(ZEXY_TARGETS)
 
@@ -2559,6 +2548,7 @@ IEMTAB_FLAGS := -DIEMTAB_SINGLE_OBJ
 
 iem_tab: $(IEMTAB_TARGETS)
 
+ifneq ($(EMSCRIPTEN),yes)
 $(IEMTAB_TARGETS) : %.$(EXTENSION) : %.o $(IEMTAB_OBJ)
 	$(CC) $(LDFLAGS) -o $*.$(EXTENSION) "$*.o" $(externals_src)/iem/iem_tab/src/iem_tab.o $(LIBS)
 	$(STRIP) $*.$(EXTENSION)
@@ -2567,6 +2557,13 @@ $(IEMTAB_TARGETS) : %.$(EXTENSION) : %.o $(IEMTAB_OBJ)
 
 $(IEMTAB_OBJ) : %.o : %.c
 	$(CC) $(CFLAGS) $(IEMTAB_FLAGS) -o "$*.o" -c "$*.c"
+else
+$(IEMTAB_OBJ): $(IEMTAB_SRC)
+	$(CC) $(CFLAGS) $(IEMTAB_FLAGS) -o "$*.o" -c "$*.c"
+
+$(IEMTAB_TARGETS): $(IEMTAB_OBJ)
+	$(CC) $(LDFLAGS) $(IEMTAB_FLAGS) -o $*.$(EXTENSION) $*.o $(LIBS)
+endif
 
 iem_tab_install: iem_tab
 	install -d $(DESTDIR)$(objectsdir)/$(IEMTAB_NAME)
@@ -2677,10 +2674,10 @@ $(IEMGUI_OBJ) : %.o : %.c
 	$(CC) $(CFLAGS) $(IEMGUI_FLAGS) -o "$*.o" -c "$*.c"
 else
 $(IEMGUI_OBJ): $(IEMGUI_SRC)
-	$(CC) $(CFLAGS) $(IEM_FLAGS) $(IEMGUI_FLAGS) -o "$*.o" -c "$*.c"
+	$(CC) $(CFLAGS) $(IEMGUI_FLAGS) -o "$*.o" -c "$*.c"
 
 $(IEMGUI_TARGETS): $(IEMGUI_OBJ)
-	$(CC) $(LDFLAGS) $(IEM_FLAGS) $(IEMGUI_FLAGS) -o $*.$(EXTENSION) $*.o $(externals_src)/iem/iemgui/src/iemgui.o $(LIBS)
+	$(CC) $(LDFLAGS) $(IEMGUI_FLAGS) -o $*.$(EXTENSION) $*.o $(externals_src)/iem/iemgui/src/iemgui.o $(LIBS)
 endif
 
 iemgui_install: iemgui

--- a/pd/src/x_connective.c
+++ b/pd/src/x_connective.c
@@ -258,16 +258,28 @@ static void bang_bang(t_bang *x)
     outlet_bang(x->x_obj.ob_outlet);
 }
 
+static void bang_float(t_bang *x, t_float f) {
+    outlet_bang(x->x_obj.ob_outlet);
+}
+
+static void bang_symbol(t_bang *x, t_symbol *s) {
+    outlet_bang(x->x_obj.ob_outlet);
+}
+
+static void bang_list(t_bang *x, t_symbol *s, int argc, t_atom *argv) {
+    outlet_bang(x->x_obj.ob_outlet);
+}
+
 void bang_setup(void)
 {
     bang_class = class_new(gensym("bang"), (t_newmethod)bang_new, 0,
         sizeof(t_bang), 0, 0);
     class_addcreator((t_newmethod)bang_new2, gensym("b"), 0);
     class_addbang(bang_class, bang_bang);
-    class_addfloat(bang_class, bang_bang);
-    class_addsymbol(bang_class, bang_bang);
-    class_addlist(bang_class, bang_bang);
-    class_addanything(bang_class, bang_bang);
+    class_addfloat(bang_class, bang_float);
+    class_addsymbol(bang_class, bang_symbol);
+    class_addlist(bang_class, bang_list);
+    class_addanything(bang_class, bang_list);
 }
 
 /* -------------------- send ------------------------------ */

--- a/webpdl2ork.Dockerfile
+++ b/webpdl2ork.Dockerfile
@@ -3,7 +3,7 @@ FROM emscripten/emsdk AS builder
 WORKDIR /pd-l2ork/
 RUN apt-get update && apt-get upgrade -y && apt-get install -y autoconf pkgconf
 COPY . .
-RUN cd emscripten; make clean; make
+RUN git submodule update --init --recursive; cd emscripten; make clean; make
 
 # Create container used to run WebPdL2Ork (without the bloat of all the build tools)
 FROM node:current-alpine


### PR DESCRIPTION
- Added remaining externals to emscriptem (pdjs, pdlua, gem are now the only unsupported externals)
- Enabled caching of main.data/main.wasm. Should make things load *much* faster, as the initial ~60MB download will only happen once. Also, enabled compression of these things, reducing the ~60MB download to ~20MB
- Fixed keyboard on android
- Fixed touch event inconsistencies
- Fixed errors from request headers being too large
- Fixed issues for patches with no connections
- Fixed building docker comtainer from clean repo
- Build process speedups/improvements. Docker container should build much faster (it now uses all cores to build externals, so on a 20 core server it will build externals 20x faster)
- Patches are no longer included in the docker container. This fixes the issue where the patches that existed when the container was built would be used instead of the patches that were provided while it was running.