### PR TITLE
Bezier array bugfixes

### DIFF
--- a/pd/src/g_array.c
+++ b/pd/src/g_array.c
@@ -213,6 +213,7 @@ static t_garray *graph_scalar(t_glist *gl, t_symbol *s, t_symbol *templatesym,
         fill, 1);
     template_setsymbol(template, gensym("outlinecolor"), x->x_scalar->sc_vec,
         outline, 1);
+    template_setfloat(template_findbyname(x->x_scalar->sc_template), gensym("linewidth"), x->x_scalar->sc_vec, 1, 0);
     glist_add(gl, &x->x_gobj);
     x->x_glist = gl;
     char buf[MAXPDSTRING];

--- a/pd/src/g_array.c
+++ b/pd/src/g_array.c
@@ -1170,6 +1170,7 @@ int array_doclick(t_array *array, t_glist *glist, t_scalar *sc, t_array *ap,
             //post("has %d arrays pwpix=%f width=%f",
             //    canvas_hasarray(glist), pwpix, pxpix2 - pxpix1);
             clickable_width = (int)((pxpix2 - pxpix1) / 2);
+            clickable_width = clickable_width < 1 ? 1 : clickable_width;
             if (xpix >= (int)pxpix1-clickable_width &&
                     xpix <= (int)pxpix2+clickable_width &&
                 // if we have multiple arrays in the same window, make array

--- a/pd/src/g_template.c
+++ b/pd/src/g_template.c
@@ -6020,7 +6020,6 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
     t_scalar *sc, t_word *data, t_template *template,
     t_float basex, t_float basey, t_array *parentarray, int tovis)
 {
-    printf("Drawing\n");
     //post("plot_vis %d %zx", tovis, (t_uint)z);
     t_plot *x = (t_plot *)z;
     int elemsize, yonset, wonset, xonset, i;
@@ -6219,7 +6218,6 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
         }
         else if (style == PLOTSTYLE_BEZ)
         {
-            printf("Drawing Bez\n");
             int ndrawn = 0;
 
             gui_start_vmess("gui_plot_vis", "xii", glist_getcanvas(glist), basex, basey);
@@ -6284,8 +6282,6 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
                 }
                 if (ndrawn > 2000 || ixpix >= 3000) break;
             }
-
-            printf("Bez drew %d of %d\n", ndrawn, nelem);
 
             gui_end_array();
 

--- a/pd/src/g_template.c
+++ b/pd/src/g_template.c
@@ -6225,6 +6225,7 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
 
             float bezierFactor = 0.4;
             
+            xsum = xloc;
             for(int i=0; i< nelem; i++) {
                 int ixpix, inextx, render;
 
@@ -6266,15 +6267,15 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
 
                 if (i == 0 || i == nelem-1 || render)
                 {
-                    ixpix = fielddesc_cvttocoord(xfielddesc, usexloc);
+                    int pix = fielddesc_cvttocoord(xfielddesc, usexloc);
                     if(i == 0) {
                         gui_s("M");
                     } else {
                         gui_s("S");
-                        gui_f((float)ixpix - bezierFactor);
+                        gui_f((float)pix - bezierFactor);
                         gui_f((1.f+bezierFactor)*yval - bezierFactor*nyval);
                     }
-                    gui_i(ixpix);
+                    gui_i(pix);
                     gui_f(yval);
 
                     ndrawn++;

--- a/pd/src/g_template.c
+++ b/pd/src/g_template.c
@@ -6020,6 +6020,7 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
     t_scalar *sc, t_word *data, t_template *template,
     t_float basex, t_float basey, t_array *parentarray, int tovis)
 {
+    printf("Drawing\n");
     //post("plot_vis %d %zx", tovis, (t_uint)z);
     t_plot *x = (t_plot *)z;
     int elemsize, yonset, wonset, xonset, i;
@@ -6218,6 +6219,7 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
         }
         else if (style == PLOTSTYLE_BEZ)
         {
+            printf("Drawing Bez\n");
             int ndrawn = 0;
 
             gui_start_vmess("gui_plot_vis", "xii", glist_getcanvas(glist), basex, basey);
@@ -6282,6 +6284,8 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
                 }
                 if (ndrawn > 2000 || ixpix >= 3000) break;
             }
+
+            printf("Bez drew %d of %d\n", ndrawn, nelem);
 
             gui_end_array();
 

--- a/pd/src/g_template.c
+++ b/pd/src/g_template.c
@@ -6403,7 +6403,7 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_glist *parentglist,
                 gui_start_array();
 
                 gui_s("stroke-width");
-                gui_f(1);
+                gui_f(linewidth);
                 gui_s("vector-effect");
                 gui_s("non-scaling-stroke");
                 gui_s("stroke");


### PR DESCRIPTION
- Fix not being able to edit extremely large arrays
- Fix extremely large bezier arrays not drawing correctly
- The issue where arrays would stop rendering seems to (hopefully?) be gone, after making some of the other changes I was unable to reproduce it anymore (though I am not sure what, if anything, stopped it, so it could just be inconsistent behavior). It seemed to happen the most on Windows (lesser so on linux, none on macos) but now I can't get it to happen anywhere.
- None of the issues were present on WebPdL2Ork as far as I can tell