### PR TITLE
PD 0.55 oscparse and soundfiler ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: "3"
 services:
   webpdl2ork:
-    build: 
-      context: .
-      dockerfile: webpdl2ork.Dockerfile
+    image: ghcr.io/pd-l2ork/pd-l2ork # Pre-built GitHub image
+    # build: # Local Image
+    #   context: .
+    #   dockerfile: webpdl2ork.Dockerfile
     #ports:
     #  - "3000:80" # Serve without proxy
     environment:
@@ -18,6 +19,7 @@ services:
     image: nginxproxy/nginx-proxy:alpine
     ports:
       - "3000:443" # Serve using https (requires certificates)
+      # - "3000:80" # Serve using http
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs

--- a/emscripten/build/Makefile
+++ b/emscripten/build/Makefile
@@ -22,7 +22,7 @@ SRC_FILES = $(SRC_DIR)/main.cpp $(SRC_DIR)/pd.cpp $(SRC_DIR)/js.cpp
 TARGET = main.html
 OUTPUT_FILES = $(TARGET) main.js main.wasm $(wildcard main-*.data)
 CFLAGS = -I$(PD_PATH)/src -I$(LIBPD_PATH)/libpd_wrapper -O3
-LDFLAGS = -L$(LIBPD_PATH)/libs -lpd -lm -sENVIRONMENT=web -sSTACK_SIZE=1048576
+LDFLAGS = -L$(LIBPD_PATH)/libs -lpd -lm -sENVIRONMENT=web -sSTACK_SIZE=1048576 -sWEBSOCKET_URL=ws://
 ifeq ($(DEBUG), true)
     CFLAGS = -I$(PD_PATH)/src -I$(LIBPD_PATH)/libpd_wrapper -gsource-map -O0 -fsanitize=address
     LDFLAGS += -sASSERTIONS=2 -sEXCEPTION_DEBUG -sSTACK_OVERFLOW_CHECK=1 --profiling-funcs

--- a/emscripten/build/Makefile
+++ b/emscripten/build/Makefile
@@ -22,7 +22,7 @@ SRC_FILES = $(SRC_DIR)/main.cpp $(SRC_DIR)/pd.cpp $(SRC_DIR)/js.cpp
 TARGET = main.html
 OUTPUT_FILES = $(TARGET) main.js main.wasm $(wildcard main-*.data)
 CFLAGS = -I$(PD_PATH)/src -I$(LIBPD_PATH)/libpd_wrapper -O3
-LDFLAGS = -L$(LIBPD_PATH)/libs -lpd -lm -sENVIRONMENT=web -sSTACK_SIZE=1048576 -sWEBSOCKET_URL=ws://
+LDFLAGS = -L$(LIBPD_PATH)/libs -lpd -lm -sENVIRONMENT=web -sSTACK_SIZE=1048576
 ifeq ($(DEBUG), true)
     CFLAGS = -I$(PD_PATH)/src -I$(LIBPD_PATH)/libpd_wrapper -gsource-map -O0 -fsanitize=address
     LDFLAGS += -sASSERTIONS=2 -sEXCEPTION_DEBUG -sSTACK_OVERFLOW_CHECK=1 --profiling-funcs

--- a/emscripten/projects/WebPdL2Ork/index.js
+++ b/emscripten/projects/WebPdL2Ork/index.js
@@ -98,7 +98,7 @@ wsServer.on('connection', client => {
     // If we haven't set up the connection yet, set it up
     if (!target) {
       // Determine hostname and port from original connection url that was intercepted
-      const [_, host, port] = msg.match(/^(?:wss?:\/\/)?([^:/]+)(?::(\d+))?/);
+      const [_, host, port] = msg.toString().match(/^(?:wss?:\/\/)?([^:/]+)(?::(\d+))?/);
       if (!host || !port) // First message must contain a hostname and port
         return client.close();
 

--- a/emscripten/projects/WebPdL2Ork/index.js
+++ b/emscripten/projects/WebPdL2Ork/index.js
@@ -1,5 +1,7 @@
 const axios = require("axios");
 const express = require("express");
+const ws = require("ws");
+const net = require('net')
 const compression = require("compression");
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -84,7 +86,52 @@ app.post("/api/file", async (req, res) => {
     res.sendStatus(204);
 });
 
-// start listening
-app.listen(PORT, () => {
+// Websocket server to proxy network requests. All network connections
+// from WebPdL2Ork will be sent to this server, along with a message
+// containing the host to connect to. We then proxy all data between
+// the user and that host.
+const wsServer = new ws.Server({ noServer: true });
+wsServer.on('connection', client => {
+  let target; // The host to proxy
+  
+  client.on('message', msg => {
+    // If we haven't set up the connection yet, set it up
+    if (!target) {
+      // Determine hostname and port from original connection url that was intercepted
+      const [_, host, port] = msg.match(/^(?:wss?:\/\/)?([^:/]+)(?::(\d+))?/);
+      if (!host || !port) // First message must contain a hostname and port
+        return client.close();
+
+      // Connect to the remote host and set up data proxy
+      target = net.createConnection(port, host);
+      target.on('data', data => {
+        try {
+          client.send(data);
+        } catch (e) {
+          target.end();
+        }
+      });
+      target.on('end', () => client.close());
+      target.on('error', () => {
+        target.end();
+        client.close();
+      });
+    }
+    else // Otherwise, proxy all data
+      target.write(msg);
+  });
+  client.on('close', () => target?.end?.());
+  client.on('error', () => target?.end?.());
+});
+
+// Start listening
+const server = app.listen(PORT, () => {
   console.log(`Pd-L2Ork Server: running on localhost port ${PORT}`)
+});
+
+// Connect to websocket server
+server.on('upgrade', (request, socket, head) => {
+  wsServer.handleUpgrade(request, socket, head, socket => {
+    wsServer.emit('connection', socket, request);
+  });
 });

--- a/emscripten/projects/WebPdL2Ork/package.json
+++ b/emscripten/projects/WebPdL2Ork/package.json
@@ -11,8 +11,9 @@
   "author": "Zack Lee",
   "license": "GPLV3",
   "dependencies": {
-    "axios": "^1.7.2",
-    "compression": "^1.7.4",
-    "express": "^4.17.1"
+    "axios": "^1.7.9",
+    "compression": "^1.7.5",
+    "express": "^4.21.2",
+    "ws": "^8.18.0"
   }
 }

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -1528,7 +1528,7 @@ var Module = {
             pd.addToHelpPath(helpPath);
             pd.addToSearchPath(extPath);
             pd.addToHelpPath(extPath);
-            var dir = FS.readdir(extPath);
+            var dir = FS.readdir(extPath).sort();
             for (var i = 0; i < dir.length; i++) {
                 var item = dir[i];
                 if (item.charAt(0) != ".") {

--- a/emscripten/projects/WebPdL2Ork/public/js/main.js
+++ b/emscripten/projects/WebPdL2Ork/public/js/main.js
@@ -1,4 +1,5 @@
 const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+const websocket = window.WebSocket;
 const loading = document.getElementById("loading");
 const filter = document.getElementById("filter");
 let currentFile = '';
@@ -93,6 +94,17 @@ let known_objects = [
   ]
 //END CONSTANTS
 
+// NETWORKING SUPPORT
+// Here we intercept all websocket connections and send them to the backend for proxying
+window.WebSocket = function (host, ...arguments) {
+    // Open a websocket to the backend
+    const socket = new websocket(`${window.location.protocol === 'http:' ? 'ws' : 'wss'}://${window.location.host}`, ...arguments);
+    
+    // Immediately send the actual host to connect to, so the backend can connect on our behalf
+    socket.addEventListener('open', () => socket.send(host));
+    
+    return socket;
+}
 
 
 //For Arrays/Graphs/Data Structures

--- a/pd/nw/pdgui.js
+++ b/pd/nw/pdgui.js
@@ -8973,9 +8973,11 @@ exports.file_dialog_obj = file_dialog_obj;
 
 function gui_openpanel(cid, target, path, mode) {
     path = path || "./";
-    if(nw_os_is_osx)
+    if(nw_os_is_osx || nw_os_is_linux)
         if(!path.endsWith('/'))
             path += '/';
+    if(nw_os_is_linux)
+        path += '*';
     //post("gui_openpanel "+cid+" "+mode+" "+target+" <"+path+">");
     pdsend(file_dialog_object, "trigger", mode, target, path);
 }

--- a/pd/src/x_misc.c
+++ b/pd/src/x_misc.c
@@ -12,6 +12,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -408,6 +409,8 @@ static t_class *oscparse_class;
 typedef struct _oscparse
 {
     t_object x_obj;
+    t_outlet *x_address_n;
+    int x_flag;
 } t_oscparse;
 
 #define ROUNDUPTO4(x) (((x) + 3) & (~3))
@@ -502,9 +505,23 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
     dataonset = ROUNDUPTO4(i + 1);
     /* post("outc %d, typeonset %d, dataonset %d, nfield %d", outc, typeonset,
         dataonset, nfield); */
+    int address_n;
     for (i = j = 0; i < typeonset-1 && argv[i].a_w.w_float != 0 &&
         j < outc; j++)
-            SETSYMBOL(outv+j, grabstring(argc, argv, &i, 1));
+    {
+        if(x->x_flag)
+        {
+            t_symbol *sym = grabstring(argc, argv, &i, 1);
+            t_float f = 0.0f;
+            char *str_end = NULL;
+            f = strtod(sym->s_name, &str_end);
+            if (f == 0 && sym->s_name == str_end)
+                SETSYMBOL(outv+j, sym);
+            else SETFLOAT(outv+j, f);
+        }
+        else SETSYMBOL(outv+j, grabstring(argc, argv, &i, 1));
+        address_n = j + 1;
+    }
     for (i = typeonset, k = dataonset; i < typeonset + nfield; i++)
     {
         union
@@ -576,6 +593,7 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
                 (int)(argv[i].a_w.w_float), (int)(argv[i].a_w.w_float));
         }
     }
+    outlet_float(x->x_address_n, address_n);
     outlet_list(x->x_obj.ob_outlet, 0, j, outv);
     return;
 tooshort:
@@ -585,7 +603,13 @@ tooshort:
 static t_oscparse *oscparse_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_oscparse *x = (t_oscparse *)pd_new(oscparse_class);
+    x->x_flag = 0;
+    if (argc && argv[0].a_w.w_symbol == gensym("-n"))
+    {
+        x->x_flag = 1;
+    }
     outlet_new(&x->x_obj, gensym("list"));
+    x->x_address_n = outlet_new((t_object *)x, &s_float);
     return (x);
 }
 


### PR DESCRIPTION
Ported the following two features from PD 0.55:

The [oscparse] object was updated by Porres to allow numeric addresses via a new '-n' flag and a right outlet was added to output split point between address and message.
64-bit soundfile reading and writing support